### PR TITLE
address minor warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,8 @@ message(STATUS "ENABLE_CRASH_LOGGER is " ${ENABLE_CRASH_LOGGER})
 option(COMPILE_DEV_HELPER "Compile with the 'DEBUG' fpreprocessor flag" OFF)
 message(STATUS "COMPILE_DEV_HELPER is " ${COMPILE_DEV_HELPER})
 
+cmake_policy(SET CMP0074 NEW)
+
 # Check if serious proton dir is set.
 if(NOT DEFINED SERIOUS_PROTON_DIR)
  message(FATAL_ERROR "SERIOUS_PROTON_DIR was not set. Unable to continue")

--- a/src/gui/gui2_textentry.h
+++ b/src/gui/gui2_textentry.h
@@ -15,8 +15,8 @@ protected:
     func_t func;
     func_t enter_func;
     sf::Clock blink_clock;
-    bool valid;
     Validator validator_func;
+    bool valid;
 public:
     GuiTextEntry(GuiContainer* owner, string id, string text);
 


### PR DESCRIPTION
set `find_package` policy in CMake to new (use `<PackageName>_ROOT` variable)
fix order of fields in textentry