### PR TITLE
Logintern

### DIFF
--- a/src/gameGlobalInfo.cpp
+++ b/src/gameGlobalInfo.cpp
@@ -33,6 +33,8 @@ GameGlobalInfo::GameGlobalInfo()
     use_system_damage = true;
     allow_main_screen_tactical_radar = true;
     allow_main_screen_long_range_radar = true;
+    allow_main_screen_global_range_radar = true;
+    allow_main_screen_ship_state = true;
     
     intercept_all_comms_to_gm = false;
 
@@ -46,6 +48,8 @@ GameGlobalInfo::GameGlobalInfo()
     registerMemberReplication(&use_system_damage);
     registerMemberReplication(&allow_main_screen_tactical_radar);
     registerMemberReplication(&allow_main_screen_long_range_radar);
+    registerMemberReplication(&allow_main_screen_global_range_radar);
+    registerMemberReplication(&allow_main_screen_ship_state);
 
     for(unsigned int n=0; n<factionInfo.size(); n++)
         reputation_points.push_back(0);

--- a/src/gameGlobalInfo.h
+++ b/src/gameGlobalInfo.h
@@ -76,6 +76,8 @@ public:
     bool use_system_damage;
     bool allow_main_screen_tactical_radar;
     bool allow_main_screen_long_range_radar;
+    bool allow_main_screen_global_range_radar;
+    bool allow_main_screen_ship_state;
     string variation = "None";
 
     //List of script functions that can be called from the GM interface (Server only!)

--- a/src/gui/gui2_scrollbar.cpp
+++ b/src/gui/gui2_scrollbar.cpp
@@ -125,3 +125,14 @@ int GuiScrollbar::getMin() const
 {
     return min_value;
 }
+
+void GuiScrollbar::onHotkey(const HotkeyResult& key)
+{
+    if (key.category == "GENERAL")
+    {
+        if (key.hotkey == "ARROW_UP")
+            setValue(getValue() - 1);
+        if (key.hotkey == "ARROW_DOWN")
+			setValue(getValue() + 1);
+    }
+}

--- a/src/gui/gui2_scrollbar.h
+++ b/src/gui/gui2_scrollbar.h
@@ -18,7 +18,8 @@ protected:
 public:
     GuiScrollbar(GuiContainer* owner, string id, int min_value, int max_value, int start_value, func_t func);
 
-    virtual void onDraw(sf::RenderTarget& window);
+    virtual void onDraw(sf::RenderTarget& window) override;
+	virtual void onHotkey(const HotkeyResult& key) override;
     virtual bool onMouseDown(sf::Vector2f position);
     virtual void onMouseDrag(sf::Vector2f position);
     virtual void onMouseUp(sf::Vector2f position);

--- a/src/gui/hotkeyConfig.cpp
+++ b/src/gui/hotkeyConfig.cpp
@@ -65,7 +65,10 @@ HotkeyConfig::HotkeyConfig()
     newKey("DISABLE_AIM_LOCK", std::make_tuple("Disable missile aim lock", ""));
     newKey("AIM_MISSILE_LEFT", std::make_tuple("Turn missile aim to the left", ""));
     newKey("AIM_MISSILE_RIGHT", std::make_tuple("Turn missile aim to the right", ""));
-    
+    newKey("SHIELD_CAL_INC", std::make_tuple("Increase shield frequency target", ""));
+    newKey("SHIELD_CAL_DEC", std::make_tuple("Decrease shield frequency target", ""));
+    newKey("SHIELD_CAL_START", std::make_tuple("Start shield calibration", ""));
+
     newCategory("ENGINEERING", "Engineering");
     newKey("SELECT_REACTOR", std::make_tuple("Select reactor system", "Num1"));
     newKey("SELECT_BEAM_WEAPONS", std::make_tuple("Select beam weapon system", "Num2"));
@@ -91,6 +94,53 @@ HotkeyConfig::HotkeyConfig()
     newKey("SELF_DESTRUCT_START", std::make_tuple("Start self-destruct", ""));
     newKey("SELF_DESTRUCT_CONFIRM", std::make_tuple("Confirm self-destruct", ""));
     newKey("SELF_DESTRUCT_CANCEL", std::make_tuple("Cancel self-destruct", ""));
+    newKey("ACTIVE_AUTO_COOLANT", std::make_tuple("Activation Auto coolant", ""));
+    newKey("ACTIVE_AUTO_REPAIR", std::make_tuple("Activation Auto repair", ""));
+  
+    newCategory("POWER_MANAGEMENT", "Power Management");
+    for(int n=0; n<SYS_COUNT; n++)
+    {
+        newKey(getSystemName(ESystem(n))+ string("_POWER_UP"),  std::make_tuple(getSystemName(ESystem(n))+ string(" Power Up"), ""));
+        newKey(getSystemName(ESystem(n))+ string("_POWER_DOWN"),  std::make_tuple(getSystemName(ESystem(n))+ string(" Power Down"), ""));
+        newKey(getSystemName(ESystem(n))+ string("_COOLANT_UP"),  std::make_tuple(getSystemName(ESystem(n))+ string(" Coolant Up"), ""));
+        newKey(getSystemName(ESystem(n))+ string("_COOLANT_DOWN"),  std::make_tuple(getSystemName(ESystem(n))+string(" Coolant Down"), ""));
+        newKey(getSystemName(ESystem(n))+ string("_RESET"),  std::make_tuple(getSystemName(ESystem(n))+string(" Reset"), ""));
+    }
+    
+   newCategory("SCIENCE", "Science");
+   newKey("NEXT_ENEMY_SCAN", std::make_tuple("Select next target", ""));
+   newKey("NEXT_SCAN", std::make_tuple("Select next target (any)", ""));
+   newKey("SCAN_START", std::make_tuple("Start scan", ""));
+   newKey("NEXT_INFO_TARGET", std::make_tuple("Next info on target", ""));
+   newKey("SELECT_TACTICAL", std::make_tuple("Select tactical info", ""));
+   newKey("SELECT_SYSTEMS", std::make_tuple("Select systems info", ""));
+   newKey("SELECT_DESCRIPTION", std::make_tuple("Select description info", ""));
+   newKey("SHOW_DATABASE", std::make_tuple("Show database", ""));
+   newKey("SHOW_PROBE", std::make_tuple("Show probe view", ""));
+   newKey("SHOW_RADAR", std::make_tuple("Show radar", ""));
+   newKey("INCREASE_ZOOM", std::make_tuple("Increase Zoom", ""));
+   newKey("DECREASE_ZOOM", std::make_tuple("Decrease Zoom", ""));
+   for(int n=0; n<3; n++)
+   {
+       newKey("MOVE_LEFT_SCAN_" + string(n+1), std::make_tuple("Move left scan " + string(n+1), ""));
+       newKey("MOVE_RIGHT_SCAN_" + string(n+1), std::make_tuple("Move right scan " + string(n+1), ""));
+   }
+    
+    newCategory("RELAY", "Relay");
+    newKey("OPEN_COMM", std::make_tuple("Open communication", ""));
+    newKey("NEXT_ENEMY_RELAY", std::make_tuple("Select next target", ""));
+    newKey("NEXT_RELAY", std::make_tuple("Select next target (any)", ""));
+    newKey("LINK_SCIENCE", std::make_tuple("Link probe to science", ""));
+    newKey("BEGIN_HACK", std::make_tuple("Begin Hack", ""));
+    newKey("ADD_WAYPOINT", std::make_tuple("Add a waypoint", ""));
+    newKey("DELETE_WAYPOINT", std::make_tuple("Delelte waypoint", ""));
+    newKey("LAUNCH_PROBE", std::make_tuple("Launch probe", ""));
+    newKey("INCREASE_ZOOM", std::make_tuple("Increase Zoom", ""));
+    newKey("DECREASE_ZOOM", std::make_tuple("Decrease Zoom", ""));
+    newKey("OPEN_LOG", std::make_tuple("Open log", ""));
+    newKey("ALERTE_NORMAL", std::make_tuple("Alert normal", ""));
+    newKey("ALERTE_YELLOW", std::make_tuple("Alert yellow", ""));
+    newKey("ALERTE_RED", std::make_tuple("Alert red", ""));
 
 }
 
@@ -218,9 +268,7 @@ std::vector<HotkeyResult> HotkeyConfig::getHotkey(sf::Event::KeyEvent key)
         for(HotkeyConfigItem& item : cat.hotkeys)
         {
             if (item.hotkey.code == key.code && item.hotkey.alt == key.alt && item.hotkey.control == key.control && item.hotkey.shift == key.shift && item.hotkey.system == key.system)
-            {
                 results.emplace_back(cat.key, item.key);
-            }
         }
     }
     return results;

--- a/src/menus/serverCreationScreen.cpp
+++ b/src/menus/serverCreationScreen.cpp
@@ -31,6 +31,8 @@ ServerCreationScreen::ServerCreationScreen()
     gameGlobalInfo->use_system_damage = PreferencesManager::get("server_config_use_system_damage", "1").toInt();
     gameGlobalInfo->allow_main_screen_tactical_radar = PreferencesManager::get("server_config_allow_main_screen_tactical_radar", "1").toInt();
     gameGlobalInfo->allow_main_screen_long_range_radar = PreferencesManager::get("server_config_allow_main_screen_long_range_radar", "1").toInt();
+    gameGlobalInfo->allow_main_screen_global_range_radar = PreferencesManager::get("server_config_allow_main_screen_global_range_radar", "1").toInt();
+    gameGlobalInfo->allow_main_screen_ship_state = PreferencesManager::get("server_config_allow_main_screen_ship_state", "1").toInt();
 
     // Create a two-column layout.
     GuiElement* container = new GuiAutoLayout(this, "", GuiAutoLayout::ELayoutMode::LayoutVerticalColumns);
@@ -109,6 +111,15 @@ ServerCreationScreen::ServerCreationScreen()
         gameGlobalInfo->allow_main_screen_long_range_radar = value == 1;
     }))->setValue(gameGlobalInfo->allow_main_screen_long_range_radar)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterRight);
 
+    row = new GuiAutoLayout(left_panel, "", GuiAutoLayout::LayoutHorizontalLeftToRight);
+    row->setSize(GuiElement::GuiSizeMax, 50);
+    (new GuiToggleButton(row, "MAIN_GLOBAL_RANGE_TOGGLE", "Global radar", [](bool value) {
+        gameGlobalInfo->allow_main_screen_global_range_radar = value == 1;
+    }))->setValue(gameGlobalInfo->allow_main_screen_global_range_radar)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterLeft);
+    (new GuiToggleButton(row, "MAIN_SHIP_STATE", "Ship State", [](bool value) {
+        gameGlobalInfo->allow_main_screen_ship_state = value == 1;
+    }))->setValue(gameGlobalInfo->allow_main_screen_ship_state)->setSize(275, GuiElement::GuiSizeMax)->setPosition(0, 0, ACenterRight);
+    
     // Game rules section.
     (new GuiLabel(left_panel, "GAME_RULES_LABEL", "Game rules", 30))->addBackground()->setSize(GuiElement::GuiSizeMax, 50);
 
@@ -234,6 +245,8 @@ void ServerCreationScreen::startScenario()
     PreferencesManager::set("server_config_use_system_damage", string(int(gameGlobalInfo->use_system_damage)));
     PreferencesManager::set("server_config_allow_main_screen_tactical_radar", string(int(gameGlobalInfo->allow_main_screen_tactical_radar)));
     PreferencesManager::set("server_config_allow_main_screen_long_range_radar", string(int(gameGlobalInfo->allow_main_screen_long_range_radar)));
+    PreferencesManager::set("server_config_allow_main_screen_global_range_radar", string(int(gameGlobalInfo->allow_main_screen_global_range_radar)));
+    PreferencesManager::set("server_config_allow_main_screen_ship_state", string(int(gameGlobalInfo->allow_main_screen_ship_state)));
 
     // Start the selected scenario.
     gameGlobalInfo->startScenario(selected_scenario_filename);

--- a/src/menus/shipSelectionScreen.cpp
+++ b/src/menus/shipSelectionScreen.cpp
@@ -434,6 +434,7 @@ void ShipSelectionScreen::updateCrewTypeOptions()
         crew_position_button[damageControl]->show();
         crew_position_button[powerManagement]->show();
         crew_position_button[databaseView]->show();
+        crew_position_button[logView]->show();
         break;
     case 3:
         main_screen_button->hide();

--- a/src/playerInfo.cpp
+++ b/src/playerInfo.cpp
@@ -150,6 +150,8 @@ void PlayerInfo::spawnUI()
             screen->addStationTab(new PowerManagementScreen(screen), powerManagement, getCrewPositionName(powerManagement), getCrewPositionIcon(powerManagement));
         if (crew_position[databaseView])
             screen->addStationTab(new DatabaseScreen(screen), databaseView, getCrewPositionName(databaseView), getCrewPositionIcon(databaseView));
+        if (crew_position[logView])
+            screen->addStationTab(new ShipLogScreen(screen), logView, getCrewPositionName(logView), getCrewPositionIcon(logView));
         
         //Ship log screen, if you have comms, you have ships log. (note this is mostly replaced by the [at the bottom of the screen openable log]
         if (crew_position[singlePilot])
@@ -197,6 +199,7 @@ string getCrewPositionName(ECrewPosition position)
     case damageControl: return "Damage Control";
     case powerManagement: return "Power Management";
     case databaseView: return "Database";
+    case logView: return "Log View";
     default: return "ErrUnk: " + string(position);
     }
 }
@@ -217,6 +220,7 @@ string getCrewPositionIcon(ECrewPosition position)
     case damageControl: return "";
     case powerManagement: return "";
     case databaseView: return "";
+    case logView: return "";
     default: return "ErrUnk: " + string(position);
     }
 }
@@ -257,6 +261,8 @@ template<> void convert<ECrewPosition>::param(lua_State* L, int& idx, ECrewPosit
         cp = powerManagement;
     else if (str == "database" || str == "databaseview")
         cp = databaseView;
+    else if (str == "log" || str == "logview")
+        cp = logView;
     
     else
         luaL_error(L, "Unknown value for crew position: %s", str.c_str());

--- a/src/playerInfo.h
+++ b/src/playerInfo.h
@@ -21,6 +21,7 @@ enum ECrewPosition
     damageControl,
     powerManagement,
     databaseView,
+    logView,
 
     max_crew_positions
 };

--- a/src/screenComponents/combatManeuver.cpp
+++ b/src/screenComponents/combatManeuver.cpp
@@ -47,11 +47,27 @@ void GuiCombatManeuver::onHotkey(const HotkeyResult& key)
     if (key.category == "HELMS" && my_spaceship)
     {
         if (key.hotkey == "COMBAT_LEFT")
-        {}//TODO
-        else if (key.hotkey == "COMBAT_RIGHT")
-        {}//TODO
-        else if (key.hotkey == "COMBAT_BOOST")
-        {}//TODO
+		{
+			setStrafeValue(-1.0f);
+			my_spaceship->commandCombatManeuverStrafe(-1.0f);
+		}	
+		if (key.hotkey == "COMBAT_RIGHT")
+		{
+			setStrafeValue(1.0f);
+			my_spaceship->commandCombatManeuverStrafe(1.0f);
+		}
+        if (key.hotkey == "COMBAT_BOOST")
+		{
+			setBoostValue(1.0f);
+			my_spaceship->commandCombatManeuverBoost(1.0f);
+		}
+        if (key.hotkey == "COMBAT_STOP")
+		{
+			setBoostValue(0.0f);
+			setStrafeValue(0.0f);
+			my_spaceship->commandCombatManeuverBoost(0.0f);
+			my_spaceship->commandCombatManeuverStrafe(0.0f);
+		}
     }
 }
 

--- a/src/screenComponents/databaseView.h
+++ b/src/screenComponents/databaseView.h
@@ -12,7 +12,6 @@ public:
     DatabaseViewComponent(GuiContainer* owner);
 
     bool findAndDisplayEntry(string name);
-
 private:
     bool findAndDisplayEntry(string name, P<ScienceDatabase> parent);
     //Fill the selection listbox with options from the selected_entry, or the main database list if selected_entry is nullptr

--- a/src/screenComponents/mainScreenControls.cpp
+++ b/src/screenComponents/mainScreenControls.cpp
@@ -19,6 +19,10 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
             tactical_button->setVisible(false);
         if (!gameGlobalInfo->allow_main_screen_long_range_radar)
             long_range_button->setVisible(false);
+        if (!gameGlobalInfo->allow_main_screen_global_range_radar)
+            global_range_button->setVisible(false);
+        if (!gameGlobalInfo->allow_main_screen_ship_state)
+            ship_state_button->setVisible(false);
         if (show_comms_button && onscreen_comms_active)
             show_comms_button->setVisible(false);
         if (hide_comms_button && !onscreen_comms_active)
@@ -97,6 +101,32 @@ GuiMainScreenControls::GuiMainScreenControls(GuiContainer* owner)
         closePopup();
     }));
     long_range_button = buttons.back();
+    
+    // Global-range radar button.
+    buttons.push_back(new GuiButton(this, "MAIN_SCREEN_GLOBAL_RANGE_BUTTON", "Global Range", [this]()
+    {
+        if (my_spaceship)
+        {
+            my_spaceship->commandMainScreenSetting(MSS_GlobalRange);
+        }
+        open_button->setValue(false);
+        for(GuiButton* button : buttons)
+            button->setVisible(false);
+    }));
+    global_range_button = buttons.back();
+    
+     // Ship State button.
+    buttons.push_back(new GuiButton(this, "MAIN_SCREEN_SHIP_STATE_BUTTON", "Ship State", [this]()
+    {
+        if (my_spaceship)
+        {
+            my_spaceship->commandMainScreenSetting(MSS_ShipState);
+        }
+        open_button->setValue(false);
+        for(GuiButton* button : buttons)
+            button->setVisible(false);
+    }));
+    ship_state_button = buttons.back();
 
     // If the player has control over comms, they can toggle the comms overlay
     // on the main screen.

--- a/src/screenComponents/mainScreenControls.h
+++ b/src/screenComponents/mainScreenControls.h
@@ -14,6 +14,8 @@ private:
     GuiButton* target_lock_button;
     GuiButton* tactical_button;
     GuiButton* long_range_button;
+    GuiButton* global_range_button;
+    GuiButton* ship_state_button;
     GuiButton* show_comms_button;
     GuiButton* hide_comms_button;
     bool onscreen_comms_active = false;

--- a/src/screenComponents/openCommsButton.cpp
+++ b/src/screenComponents/openCommsButton.cpp
@@ -22,3 +22,16 @@ void GuiOpenCommsButton::onDraw(sf::RenderTarget& window)
     }
     GuiButton::onDraw(window);
 }
+
+
+void GuiOpenCommsButton::onHotkey(const HotkeyResult& key)
+{
+    if (key.category == "RELAY" && my_spaceship)
+    {
+        if (key.hotkey == "OPEN_COMM")
+        {
+			if (this->targets->get())
+				my_spaceship->commandOpenTextComm(this->targets->get());
+		}
+	}
+}

--- a/src/screenComponents/openCommsButton.h
+++ b/src/screenComponents/openCommsButton.h
@@ -11,7 +11,8 @@ class GuiOpenCommsButton : public GuiButton
 public:
     GuiOpenCommsButton(GuiContainer* owner, string id, TargetsContainer* targets);
     
-    virtual void onDraw(sf::RenderTarget& window);
+    virtual void onDraw(sf::RenderTarget& window) override;
+	virtual void onHotkey(const HotkeyResult& key) override;
 };
 
 #endif//OPEN_COMMS_BUTTON_H

--- a/src/screenComponents/scanTargetButton.cpp
+++ b/src/screenComponents/scanTargetButton.cpp
@@ -42,3 +42,15 @@ void GuiScanTargetButton::onDraw(sf::RenderTarget& window)
         progress->hide();
     }
 }
+
+void GuiScanTargetButton::onHotkey(const HotkeyResult& key)
+{
+    if (key.category == "SCIENCE" && my_spaceship)
+    {
+		if (key.hotkey == "SCAN_START")
+		{
+			if (this->targets && this->targets->get())
+                my_spaceship->commandScan(this->targets->get());
+		}
+    }
+}

--- a/src/screenComponents/scanTargetButton.h
+++ b/src/screenComponents/scanTargetButton.h
@@ -16,7 +16,8 @@ private:
 public:
     GuiScanTargetButton(GuiContainer* owner, string id, TargetsContainer* targets);
     
-    virtual void onDraw(sf::RenderTarget& window);
+    virtual void onDraw(sf::RenderTarget& window) override;
+    virtual void onHotkey(const HotkeyResult& key) override;
 };
 
 #endif//SCAN_TARGET_BUTTON_H

--- a/src/screenComponents/scanningDialog.cpp
+++ b/src/screenComponents/scanningDialog.cpp
@@ -161,3 +161,30 @@ void GuiScanningDialog::updateSignal()
     signal_quality->setPeriodError(period);
     signal_quality->setPhaseError(phase);
 }
+
+void GuiScanningDialog::onHotkey(const HotkeyResult& key)
+{
+    if (key.category == "SCIENCE" && my_spaceship)
+    {
+        for(int n=0; n<max_sliders; n++)
+        {
+            if (sliders[n]->isVisible())
+            {
+                if (key.hotkey == "MOVE_LEFT_SCAN_"+string(n+1))
+                {
+                    float new_value = sliders[n]->getValue()-0.05;
+                    if (new_value <= 0.0)
+                        new_value = 0.0;
+                    sliders[n]->setValue(new_value);
+                }
+                if (key.hotkey == "MOVE_RIGHT_SCAN_"+string(n+1))
+                {
+                    float new_value = sliders[n]->getValue()+0.05;
+                    if (new_value >= 1.0)
+                        new_value = 1.0;
+                    sliders[n]->setValue(new_value);
+                }
+            }
+        }
+    }
+}

--- a/src/screenComponents/scanningDialog.h
+++ b/src/screenComponents/scanningDialog.h
@@ -29,7 +29,8 @@ private:
 public:
     GuiScanningDialog(GuiContainer* owner, string id);
 
-    virtual void onDraw(sf::RenderTarget& window);
+    virtual void onDraw(sf::RenderTarget& window) override;
+    virtual void onHotkey(const HotkeyResult& key) override;
     
     void setupParameters();
     void updateSignal();

--- a/src/screenComponents/shieldFreqencySelect.cpp
+++ b/src/screenComponents/shieldFreqencySelect.cpp
@@ -38,7 +38,7 @@ void GuiShieldFrequencySelect::onDraw(sf::RenderTarget& window)
 
 void GuiShieldFrequencySelect::onHotkey(const HotkeyResult& key)
 {
-    if (key.category == "ENGINEERING" && my_spaceship)
+    if ((key.category == "ENGINEERING" || key.category == "WEAPONS") && my_spaceship)
     {
         if (key.hotkey == "SHIELD_CAL_INC")
         {

--- a/src/screenComponents/shipsLogControl.cpp
+++ b/src/screenComponents/shipsLogControl.cpp
@@ -5,8 +5,8 @@
 #include "gui/gui2_panel.h"
 #include "gui/gui2_advancedscrolltext.h"
 
-ShipsLog::ShipsLog(GuiContainer* owner)
-: GuiElement(owner, "")
+ShipsLog::ShipsLog(GuiContainer* owner, string station)
+: GuiElement(owner, ""), station(station)
 {
     setPosition(0, 0, ABottomCenter);
     setSize(GuiElement::GuiSizeMax, 50);
@@ -26,11 +26,11 @@ void ShipsLog::onDraw(sf::RenderTarget& window)
     if (!my_spaceship)
         return;
 
-    const std::vector<PlayerSpaceship::ShipLogEntry>& logs = my_spaceship->getShipsLog();
+    const std::vector<PlayerSpaceship::ShipLogEntry>& logs = my_spaceship->getShipsLog(station);
     
     if (open)
     {
-        const std::vector<PlayerSpaceship::ShipLogEntry>& logs = my_spaceship->getShipsLog();
+        const std::vector<PlayerSpaceship::ShipLogEntry>& logs = my_spaceship->getShipsLog(station);
         if (log_text->getEntryCount() > 0 && logs.size() == 0)
             log_text->clearEntries();
 
@@ -82,4 +82,19 @@ bool ShipsLog::onMouseDown(sf::Vector2f position)
     else
         setSize(getSize().x, 50);
     return true;
+}
+
+void ShipsLog::onHotkey(const HotkeyResult& key)
+{
+    if (key.category == "RELAY" && my_spaceship)
+    {
+        if (key.hotkey == "OPEN_LOG")
+        {
+			open = !open;
+		    if (open)
+				setSize(getSize().x, 800);
+			else
+				setSize(getSize().x, 50);
+		}
+	}
 }

--- a/src/screenComponents/shipsLogControl.h
+++ b/src/screenComponents/shipsLogControl.h
@@ -9,10 +9,12 @@ class GuiAdvancedScrollText;
 class ShipsLog : public GuiElement
 {
 public:
-    ShipsLog(GuiContainer* owner);
+    string station;
+    ShipsLog(GuiContainer* owner, string station);
 
     virtual void onDraw(sf::RenderTarget& window) override;
     virtual bool onMouseDown(sf::Vector2f position) override;
+	virtual void onHotkey(const HotkeyResult& key) override;
 private:
     bool open;
     GuiAdvancedScrollText* log_text;

--- a/src/screenComponents/targetsContainer.cpp
+++ b/src/screenComponents/targetsContainer.cpp
@@ -108,3 +108,9 @@ void TargetsContainer::setWaypointIndex(int index)
     if (my_spaceship && index >= 0 && index < (int)my_spaceship->waypoints.size())
         waypoint_selection_position = my_spaceship->waypoints[index];
 }
+
+sf::Vector2f TargetsContainer::getWaypointPosition()
+{
+    if (my_spaceship && waypoint_selection_index >= 0)
+        return waypoint_selection_position;
+}

--- a/src/screenComponents/targetsContainer.h
+++ b/src/screenComponents/targetsContainer.h
@@ -29,6 +29,7 @@ public:
     P<SpaceObject> get() { entries.update(); if (entries.size() > 0) return entries[0]; return nullptr; }
     int getWaypointIndex();
     void setWaypointIndex(int index);
+    sf::Vector2f getWaypointPosition();
     
     void setToClosestTo(sf::Vector2f position, float max_range, ESelectionType selection_type);
 };

--- a/src/screenComponents/viewport3d.cpp
+++ b/src/screenComponents/viewport3d.cpp
@@ -52,7 +52,9 @@ void GuiViewport3D::onDraw(sf::RenderTarget& window)
 
     glMatrixMode(GL_PROJECTION);
     glLoadIdentity();
-    _glPerspective(camera_fov, rect.width/rect.height, 1.f, 25000.f);
+    //_glPerspective(camera_fov, rect.width/rect.height, 1.f, 25000.f);
+    _glPerspective(camera_fov, rect.width/rect.height, 1.f,  999999.f);
+
     glMatrixMode(GL_MODELVIEW);
     glLoadIdentity();
     

--- a/src/screens/crew4/operationsScreen.cpp
+++ b/src/screens/crew4/operationsScreen.cpp
@@ -75,7 +75,8 @@ OperationScreen::OperationScreen(GuiContainer* owner)
     delete_waypoint_button->setPosition(-270, -120, ABottomRight)->setSize(200, 50);
     
     mode = TargetSelection;
-    
-    new ShipsLog(this);
+
+    new ShipsLog(this,"extern");
+  
     (new GuiCommsOverlay(this))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 }

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -5,6 +5,7 @@
 #include "screenComponents/shipInternalView.h"
 #include "screenComponents/selfDestructButton.h"
 #include "screenComponents/alertOverlay.h"
+#include "screenComponents/shipsLogControl.h"
 #include "screenComponents/customShipFunctions.h"
 
 #include "gui/gui2_keyvaluedisplay.h"
@@ -34,11 +35,13 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
     front_shield_display->setIcon("gui/icons/shields-fore")->setTextSize(20)->setPosition(20, 180, ATopLeft)->setSize(240, 40);
     rear_shield_display = new GuiKeyValueDisplay(this, "SHIELDS_DISPLAY", 0.45, "Rear", "");
     rear_shield_display->setIcon("gui/icons/shields-aft")->setTextSize(20)->setPosition(20, 220, ATopLeft)->setSize(240, 40);
-
-    (new GuiSelfDestructButton(this, "SELF_DESTRUCT"))->setPosition(20, 260, ATopLeft)->setSize(240, 100);
-
+    oxygen_display = new GuiKeyValueDisplay(this, "OXYGEN_DISPLAY", 0.45, "Oxygen", "");
+    oxygen_display->setIcon("gui/icons/weapon-hvli")->setTextSize(20)->setPosition(20, 260, ATopLeft)->setSize(240, 40);
+    
+    (new GuiSelfDestructButton(this, "SELF_DESTRUCT"))->setPosition(20, 300, ATopLeft)->setSize(240, 100);
+    
     GuiElement* system_config_container = new GuiElement(this, "");
-    system_config_container->setPosition(0, -20, ABottomCenter)->setSize(750 + 300, GuiElement::GuiSizeMax);
+    system_config_container->setPosition(0, -50, ABottomCenter)->setSize(750 + 300, GuiElement::GuiSizeMax);
     GuiAutoLayout* system_row_layouts = new GuiAutoLayout(system_config_container, "SYSTEM_ROWS", GuiAutoLayout::LayoutVerticalBottomToTop);
     system_row_layouts->setPosition(0, 0, ABottomLeft);
     system_row_layouts->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
@@ -117,6 +120,8 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
     for(float snap_point = 0.0; snap_point <= 10.0; snap_point += 2.5)
         coolant_slider->addSnapValue(snap_point, 0.1);
     coolant_slider->disable();
+    
+    new ShipsLog(this,"intern");
 
     (new GuiShipInternalView(system_row_layouts, "SHIP_INTERNAL_VIEW", 48.0f))->setShip(my_spaceship)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     
@@ -161,6 +166,12 @@ void EngineeringScreen::onDraw(sf::RenderTarget& window)
             hull_display->setColor(sf::Color::White);
         front_shield_display->setValue(string(my_spaceship->getShieldPercentage(0)) + "%");
         rear_shield_display->setValue(string(my_spaceship->getShieldPercentage(1)) + "%");
+
+        oxygen_display->setValue(string(my_spaceship->getOxygenPoints(), 0));
+        if (my_spaceship->getOxygenPoints() < 20)
+            oxygen_display->setColor(sf::Color::Red);
+        else
+            oxygen_display->setColor(sf::Color::White);
 
         for(int n=0; n<SYS_COUNT; n++)
         {
@@ -315,6 +326,10 @@ void EngineeringScreen::onHotkey(const HotkeyResult& key)
                 my_spaceship->commandSetSystemCoolantRequest(selected_system, coolant_slider->getValue());
             }
         }
+		
+		if (key.hotkey == "ACTIVE_AUTO_COOLANT") my_spaceship->auto_coolant_enabled = !my_spaceship->auto_coolant_enabled;
+		if (key.hotkey == "ACTIVE_AUTO_REPAIR") my_spaceship->auto_repair_enabled = !my_spaceship->auto_repair_enabled;
+		
     }
 }
 

--- a/src/screens/crew6/engineeringScreen.h
+++ b/src/screens/crew6/engineeringScreen.h
@@ -24,6 +24,7 @@ private:
     GuiKeyValueDisplay* hull_display;
     GuiKeyValueDisplay* front_shield_display;
     GuiKeyValueDisplay* rear_shield_display;
+    GuiKeyValueDisplay* oxygen_display;
     GuiLabel* power_label;
     GuiSlider* power_slider;
     GuiLabel* coolant_label;

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -2,6 +2,7 @@
 #include "playerInfo.h"
 #include "spaceObjects/playerSpaceship.h"
 #include "spaceObjects/scanProbe.h"
+#include "spaceObjects/spaceObject.h"
 #include "scriptInterface.h"
 #include "gameGlobalInfo.h"
 
@@ -200,7 +201,7 @@ RelayScreen::RelayScreen(GuiContainer* owner)
 
     hacking_dialog = new GuiHackingDialog(this, "");
 
-    new ShipsLog(this);
+    new ShipsLog(this,"extern");
 
     (new GuiCommsOverlay(this))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 }
@@ -299,3 +300,197 @@ void RelayScreen::onDraw(sf::RenderTarget& window)
     else
         delete_waypoint_button->disable();
 }
+
+void RelayScreen::onHotkey(const HotkeyResult& key)
+{
+    if (key.category == "RELAY" && my_spaceship)
+    {
+        if (key.hotkey == "NEXT_ENEMY_RELAY")
+        {
+			bool current_found = false;
+            foreach(SpaceObject, obj, space_object_list)
+            {
+                if (obj == targets.get())
+                {
+                    current_found = true;
+                    continue;
+                }
+                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < radar->getDistance() && my_spaceship->isEnemy(obj) && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
+                {
+                    targets.set(obj);
+                    // my_spaceship->commandSetTarget(targets.get());
+                    return;
+                }
+            }
+            foreach(SpaceObject, obj, space_object_list)
+            {
+                if (obj == targets.get())
+                {
+                    continue;
+                }
+                if (my_spaceship->isEnemy(obj) && sf::length(obj->getPosition() - my_spaceship->getPosition()) < radar->getDistance() && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeTargetedBy(my_spaceship))
+                {
+                    targets.set(obj);
+                    // my_spaceship->commandSetTarget(targets.get());
+                    return;
+                }
+            }
+		}
+        if (key.hotkey == "NEXT_RELAY")
+        {
+			bool current_found = false;
+			PVector<SpaceObject> list_range;
+			PVector<SpaceObject> list_range_obj_relai;
+			
+			list_range = my_spaceship->getObjectsInRange(5000.0f);
+            foreach(SpaceObject, obj, list_range)
+			{
+				if (obj == targets.get())
+                {
+                    current_found = true;
+                    continue;
+                }
+                if (obj == my_spaceship)
+                    continue;
+                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < radar->getDistance() && obj->canBeTargetedBy(my_spaceship))
+                {
+                    targets.set(obj);
+                    return;
+                }
+			}
+            foreach(SpaceObject, obj_relai, space_object_list)
+            {
+				// P<ScanProbe> test = obj_relai;
+				if(obj_relai->isFriendly(my_spaceship))
+				{
+					list_range_obj_relai = obj_relai->getObjectsInRange(5000.0f);
+					foreach(SpaceObject, obj, list_range_obj_relai)
+					{
+						if (obj == targets.get())
+						{
+							current_found = true;
+							continue;
+						}
+						if (obj == my_spaceship)
+							continue;
+						if (current_found && sf::length(obj->getPosition() - obj_relai->getPosition()) < radar->getDistance() && obj->canBeTargetedBy(my_spaceship))
+						{
+							targets.set(obj);
+							return;
+						}
+					}
+				}                    
+            }
+			
+			list_range = my_spaceship->getObjectsInRange(5000.0f);
+            foreach(SpaceObject, obj, list_range)
+			{
+				if (obj == targets.get()  || obj == my_spaceship)
+                    continue;
+                if (sf::length(obj->getPosition() - my_spaceship->getPosition()) < radar->getDistance() && obj->canBeTargetedBy(my_spaceship))
+                {
+                    targets.set(obj);
+                    return;
+                }
+			}
+            foreach(SpaceObject, obj_relai, space_object_list)
+            {
+				// P<ScanProbe> test = probe;
+				if(obj_relai->isFriendly(my_spaceship))
+				{
+					list_range_obj_relai = obj_relai->getObjectsInRange(5000.0f);
+					foreach(SpaceObject, obj, list_range_obj_relai)
+					{
+						if (obj == targets.get() || obj == my_spaceship)
+							continue;
+						if (sf::length(obj->getPosition() - obj_relai->getPosition()) < radar->getDistance() && obj->canBeTargetedBy(my_spaceship))
+						{
+							targets.set(obj);
+							return;
+						}
+					}
+				}                
+            }
+		}
+        if (key.hotkey == "LINK_SCIENCE")
+        {
+			P<ScanProbe> obj = targets.get(); 
+            if (obj && obj->isFriendly(my_spaceship))
+			{	
+				if (!link_to_science_button->getValue())
+					my_spaceship->commandSetScienceLink(targets.get()->getMultiplayerId());
+				else
+					my_spaceship->commandSetScienceLink(-1);
+			}
+		}
+        if (key.hotkey == "BEGIN_HACK")
+		{
+			P<SpaceObject> target = targets.get();
+			if (target && target->canBeHackedBy(my_spaceship))
+			{
+				hacking_dialog->open(target);
+			}
+		}
+        if (key.hotkey == "ADD_WAYPOINT")
+        {
+			mode = WaypointPlacement;
+			option_buttons->hide();
+		}
+        if (key.hotkey == "DELETE_WAYPOINT")
+        {
+			if (targets.getWaypointIndex() >= 0)
+				my_spaceship->commandRemoveWaypoint(targets.getWaypointIndex());
+		}
+        if (key.hotkey == "LAUNCH_PROBE")
+        {
+			mode = LaunchProbe;
+			option_buttons->hide();
+		}
+        if (key.hotkey == "INCREASE_ZOOM")
+        {
+			float view_distance = radar->getDistance() + 1500.0f;
+			if (view_distance > 50000.0f)
+				view_distance = 50000.0f;
+			if (view_distance < 6250.0f)
+				view_distance = 6250.0f;
+			radar->setDistance(view_distance);
+			// Keep the zoom slider in sync.
+			zoom_slider->setValue(view_distance);
+			zoom_label->setText("Zoom: " + string(50000.0f / view_distance, 1.0f) + "x");
+		}
+		if (key.hotkey == "DECREASE_ZOOM")
+		{
+			float view_distance = radar->getDistance() - 1500.0f;
+			if (view_distance > 50000.0f)
+				view_distance = 50000.0f;
+			if (view_distance < 6250.0f)
+				view_distance = 6250.0f;
+			radar->setDistance(view_distance);
+			// Keep the zoom slider in sync.
+			zoom_slider->setValue(view_distance);
+			zoom_label->setText("Zoom: " + string(50000.0f / view_distance, 1.0f) + "x");			
+		}
+        if (key.hotkey == "ALERTE_NORMAL")
+        {
+			my_spaceship->commandSetAlertLevel(AL_Normal);
+            for(GuiButton* button : alert_level_buttons)
+                button->setVisible(false);
+            alert_level_button->setValue(false);	
+		}
+        if (key.hotkey == "ALERTE_YELLOW")
+        {
+			my_spaceship->commandSetAlertLevel(AL_YellowAlert);
+            for(GuiButton* button : alert_level_buttons)
+                button->setVisible(false);
+            alert_level_button->setValue(false);	
+		}
+        if (key.hotkey == "ALERTE_RED")
+        {
+			my_spaceship->commandSetAlertLevel(AL_RedAlert);
+            for(GuiButton* button : alert_level_buttons)
+                button->setVisible(false);
+            alert_level_button->setValue(false);	
+		}
+	}
+}
+

--- a/src/screens/crew6/relayScreen.h
+++ b/src/screens/crew6/relayScreen.h
@@ -57,7 +57,8 @@ private:
 public:
     RelayScreen(GuiContainer* owner);
 
-    virtual void onDraw(sf::RenderTarget& window);
+    virtual void onDraw(sf::RenderTarget& window) override;
+    virtual void onHotkey(const HotkeyResult& key) override;
 };
 
 #endif//RELAY_SCREEN_H

--- a/src/screens/crew6/scienceScreen.cpp
+++ b/src/screens/crew6/scienceScreen.cpp
@@ -321,6 +321,7 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
                 if (minutes < 10)
                     duration += "0";
                 duration += string(minutes%60);
+
                 duration += ":";
                 if (seconds%60 < 10)
                     duration += "0";
@@ -467,4 +468,159 @@ void ScienceScreen::onDraw(sf::RenderTarget& window)
         info_heading->setValue(string(int(heading)));
         info_relspeed->setValue(string(rel_velocity / 1000.0f * 60.0f, 1) + DISTANCE_UNIT_1K + "/min");
     }
+}
+
+void ScienceScreen::onHotkey(const HotkeyResult& key)
+{
+    if (key.category == "SCIENCE" && my_spaceship)
+    {
+        if (key.hotkey == "NEXT_ENEMY_SCAN")
+        {
+            bool current_found = false;
+            foreach(SpaceObject, obj, space_object_list)
+            {
+                if (obj == targets.get())
+                {
+                    current_found = true;
+                    continue;
+                }
+                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->long_range_radar_range && my_spaceship->isEnemy(obj) && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeSelectedBy(my_spaceship))
+                {
+                    targets.set(obj);
+                    // my_spaceship->commandSetTarget(targets.get());
+                    return;
+                }
+            }
+            foreach(SpaceObject, obj, space_object_list)
+            {
+                if (obj == targets.get())
+                {
+                    continue;
+                }
+                if (my_spaceship->isEnemy(obj) && sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->long_range_radar_range && my_spaceship->getScannedStateFor(obj) >= SS_FriendOrFoeIdentified && obj->canBeSelectedBy(my_spaceship))
+                {
+                    targets.set(obj);
+                    // my_spaceship->commandSetTarget(targets.get());
+                    return;
+                }
+            }
+        }
+        if (key.hotkey == "NEXT_SCAN")
+        {
+            bool current_found = false;
+            foreach(SpaceObject, obj, space_object_list)
+            {
+                if (obj == targets.get())
+                {
+                    current_found = true;
+                    continue;
+                }
+                if (obj == my_spaceship)
+                    continue;
+                if (current_found && sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->long_range_radar_range && obj->canBeSelectedBy(my_spaceship))
+                {
+                    targets.set(obj);
+                    // my_spaceship->commandSetTarget(targets.get());
+                    return;
+                }
+            }
+            foreach(SpaceObject, obj, space_object_list)
+            {
+                if (obj == targets.get() || obj == my_spaceship)
+                    continue;
+                if (sf::length(obj->getPosition() - my_spaceship->getPosition()) < gameGlobalInfo->long_range_radar_range && obj->canBeSelectedBy(my_spaceship))
+                {
+                    targets.set(obj);
+                    // my_spaceship->commandSetTarget(targets.get());
+                    return;
+                }
+            }
+        }
+		if (targets.get())
+		{
+			P<SpaceObject> obj = targets.get();
+			P<SpaceShip> ship = obj;
+			P<SpaceStation> station = obj;
+			if (ship)
+			{		
+				if (ship->getScannedStateFor(my_spaceship) >= SS_FullScan)
+				{
+					if (key.hotkey == "SELECT_TACTICAL" && sidebar_pager->indexByValue("Tactical"))
+						sidebar_pager->setSelectionIndex(sidebar_pager->indexByValue("Tactical"));
+					if (key.hotkey == "SELECT_SYSTEMS" && sidebar_pager->indexByValue("Systems"))
+						sidebar_pager->setSelectionIndex(sidebar_pager->indexByValue("Systems"));
+					if (key.hotkey == "SELECT_DESCRIPTION" && sidebar_pager->indexByValue("Description"))
+						sidebar_pager->setSelectionIndex(sidebar_pager->indexByValue("Description"));
+
+					if (key.hotkey == "NEXT_INFO_TARGET")
+					{
+						if (sidebar_pager->getSelectionIndex() >= sidebar_pager->entryCount() - 1)
+							sidebar_pager->setSelectionIndex(0);
+						else
+							sidebar_pager->setSelectionIndex(sidebar_pager->getSelectionIndex() + 1);
+					}
+				}
+			}
+		}
+ 		if (key.hotkey == "SHOW_PROBE")
+        {
+            P<ScanProbe> probe;
+
+            if (game_server)
+                probe = game_server->getObjectById(my_spaceship->linked_science_probe_id);
+            else
+                probe = game_client->getObjectById(my_spaceship->linked_science_probe_id);
+
+            if (probe && !probe_view_button->getValue())
+            {
+				probe_view_button->setValue(true);
+                sf::Vector2f probe_position = probe->getPosition();
+                science_radar->hide();
+                probe_radar->show();
+                probe_radar->setViewPosition(probe_position)->show();
+            }else{
+                probe_view_button->setValue(false);
+                science_radar->show();
+                probe_radar->hide();
+            }
+		}
+		if (key.hotkey == "SHOW_DATABASE")
+		{
+			view_mode_selection->setSelectionIndex(1);
+			radar_view->hide();
+			background_gradient->hide();
+			database_view->show();
+		}
+		if (key.hotkey == "SHOW_RADAR")
+		{
+			view_mode_selection->setSelectionIndex(0);
+			radar_view->show();
+			background_gradient->show();
+			database_view->hide();
+		}
+		if (key.hotkey == "INCREASE_ZOOM")
+		{
+			float view_distance = science_radar->getDistance() + 1500.0f;
+			if (view_distance > gameGlobalInfo->long_range_radar_range)
+				view_distance = gameGlobalInfo->long_range_radar_range;
+			if (view_distance < 5000.0f)
+				view_distance = 5000.0f;
+			science_radar->setDistance(view_distance);
+			// Keep the zoom slider in sync.
+			zoom_slider->setValue(view_distance);
+			zoom_label->setText("Zoom: " + string(gameGlobalInfo->long_range_radar_range / view_distance, 1) + "x");
+		}
+		if (key.hotkey == "DECREASE_ZOOM")
+		{
+			float view_distance = science_radar->getDistance() - 1500.0f;
+			if (view_distance > gameGlobalInfo->long_range_radar_range)
+				view_distance = gameGlobalInfo->long_range_radar_range;
+			if (view_distance < 5000.0f)
+				view_distance = 5000.0f;
+			science_radar->setDistance(view_distance);
+			// Keep the zoom slider in sync.
+			zoom_slider->setValue(view_distance);
+			zoom_label->setText("Zoom: " + string(gameGlobalInfo->long_range_radar_range / view_distance, 1) + "x");
+		}
+	}
 }

--- a/src/screens/crew6/scienceScreen.h
+++ b/src/screens/crew6/scienceScreen.h
@@ -63,7 +63,8 @@ public:
 public:
     ScienceScreen(GuiContainer* owner, ECrewPosition crew_position=scienceOfficer);
 
-    virtual void onDraw(sf::RenderTarget& window);
+    virtual void onDraw(sf::RenderTarget& window) override;
+    virtual void onHotkey(const HotkeyResult& key) override;
 };
 
 #endif//SCIENCE_SCREEN_H

--- a/src/screens/extra/powerManagement.cpp
+++ b/src/screens/extra/powerManagement.cpp
@@ -78,3 +78,51 @@ void PowerManagementScreen::onDraw(sf::RenderTarget& window)
         }
     }
 }
+
+void PowerManagementScreen::onHotkey(const HotkeyResult& key)
+{
+	if (key.category == "POWER_MANAGEMENT" && my_spaceship)
+    {
+		if (my_spaceship)
+		{		
+			for(int n=0; n<SYS_COUNT; n++)
+			{
+				if (key.hotkey == getSystemName(ESystem(n))+ string("_POWER_UP"))
+				{
+					if(my_spaceship->systems[n].power_request < 3.0f)
+					
+						my_spaceship->commandSetSystemPowerRequest(ESystem(n), my_spaceship->systems[n].power_request + 0.1f);
+					else
+						my_spaceship->commandSetSystemPowerRequest(ESystem(n), 3.0f);
+				}
+				if (key.hotkey == getSystemName(ESystem(n))+ string("_POWER_DOWN"))
+				{
+					if(my_spaceship->systems[n].power_request > 0.0f)
+						my_spaceship->commandSetSystemPowerRequest(ESystem(n), my_spaceship->systems[n].power_request - 0.1f);
+					else
+						my_spaceship->commandSetSystemPowerRequest(ESystem(n), 0.0f);
+				}
+				if (key.hotkey == getSystemName(ESystem(n))+ string("_COOLANT_UP"))
+				{
+					if(my_spaceship->systems[n].coolant_request < 10.0f)
+						my_spaceship->commandSetSystemCoolantRequest(ESystem(n), my_spaceship->systems[n].coolant_request + 0.5f);
+					else
+						my_spaceship->commandSetSystemCoolantRequest(ESystem(n), 10.0f);	
+				}
+				if (key.hotkey == getSystemName(ESystem(n))+ string("_COOLANT_DOWN"))
+				{
+					if(my_spaceship->systems[n].coolant_request > 0.0f)
+						my_spaceship->commandSetSystemCoolantRequest(ESystem(n), my_spaceship->systems[n].coolant_request - 0.5f);
+					else
+						my_spaceship->commandSetSystemCoolantRequest(ESystem(n), 0.0f);
+				}
+				if (key.hotkey == getSystemName(ESystem(n))+ string("_RESET"))
+				{
+					my_spaceship->commandSetSystemPowerRequest(ESystem(n), 1.0f);
+					my_spaceship->commandSetSystemCoolantRequest(ESystem(n), 0.0f);
+				}
+			}
+		}
+	}
+}
+

--- a/src/screens/extra/powerManagement.h
+++ b/src/screens/extra/powerManagement.h
@@ -26,6 +26,7 @@ public:
     PowerManagementScreen(GuiContainer* owner);
     
     void onDraw(sf::RenderTarget& window) override;
+    virtual void onHotkey(const HotkeyResult& key) override;
 };
 
 #endif//POWER_MANAGEMENT_H

--- a/src/screens/extra/shipLogScreen.cpp
+++ b/src/screens/extra/shipLogScreen.cpp
@@ -20,7 +20,7 @@ void ShipLogScreen::onDraw(sf::RenderTarget& window)
     
     if (my_spaceship)
     {
-        const std::vector<PlayerSpaceship::ShipLogEntry>& logs = my_spaceship->getShipsLog();
+        const std::vector<PlayerSpaceship::ShipLogEntry>& logs = my_spaceship->getShipsLog("extern");
         if (log_text->getEntryCount() > 0 && logs.size() == 0)
             log_text->clearEntries();
 

--- a/src/screens/gm/gameMasterScreen.cpp
+++ b/src/screens/gm/gameMasterScreen.cpp
@@ -87,6 +87,24 @@ GameMasterScreen::GameMasterScreen()
         }
     });
     sector_name_text->setText(getSectorName(main_radar->getViewPosition()));
+    CPU_ship_selector = new GuiSelector(this, "CPU_SHIP_SELECTOR", [this](int index, string value) {
+        P<SpaceObject> ship = space_object_list[value.toInt()];
+        if (ship)
+            target = ship;
+        main_radar->setViewPosition(ship->getPosition());
+        targets.set(ship);
+    });
+    CPU_ship_selector->setPosition(270, -70, ABottomLeft)->setSize(250, 50);
+
+    space_station_selector = new GuiSelector(this, "SPACE_STATION_SELECTOR", [this](int index, string value) {
+        P<SpaceObject> station = space_object_list[value.toInt()];
+        if (station)
+            target = station;
+        main_radar->setViewPosition(station->getPosition());
+        targets.set(station);
+    });
+    space_station_selector->setPosition(270, -120, ABottomLeft)->setSize(250, 50);
+    
     create_button = new GuiButton(this, "CREATE_OBJECT_BUTTON", "Create...", [this]() {
         object_creation_screen->show();
     });
@@ -248,6 +266,31 @@ void GameMasterScreen::update(float delta)
             if (player_ship_selector->indexByValue(string(n)) != -1)
                 player_ship_selector->removeEntry(player_ship_selector->indexByValue(string(n)));
         }
+    }
+    
+    // Add and remove entries from the CPU ship and space station list.
+    int n = 0;
+    foreach(SpaceObject, obj, space_object_list)
+    {
+        P<SpaceShip> ship = obj;
+        P<SpaceStation> station = obj;
+        if (ship)
+        {
+            if (CPU_ship_selector->indexByValue(string(n)) == -1)
+                CPU_ship_selector->addEntry(ship->getTypeName() + " " + ship->getCallSign(), string(n));
+            }else{
+                if (CPU_ship_selector->indexByValue(string(n)) != -1)
+                    CPU_ship_selector->removeEntry(CPU_ship_selector->indexByValue(string(n)));
+            }
+        if (station)
+        {
+            if (space_station_selector->indexByValue(string(n)) == -1)
+                space_station_selector->addEntry(station->getTypeName() + " " + station->getCallSign(), string(n));
+            }else{
+                if (space_station_selector->indexByValue(string(n)) != -1)
+                    space_station_selector->removeEntry(space_station_selector->indexByValue(string(n)));
+            }
+        n += 1;
     }
 
     // Record object type.

--- a/src/screens/gm/gameMasterScreen.h
+++ b/src/screens/gm/gameMasterScreen.h
@@ -51,6 +51,8 @@ private:
     GuiButton* copy_scenario_button;
     GuiButton* copy_selected_button;
     GuiSelector* player_ship_selector;
+    GuiSelector* CPU_ship_selector;
+    GuiSelector* space_station_selector;
     
     enum EClickAndDragState
     {

--- a/src/screens/gm/tweak.cpp
+++ b/src/screens/gm/tweak.cpp
@@ -562,6 +562,14 @@ GuiShipTweakPlayer::GuiShipTweakPlayer(GuiContainer* owner)
         target->setReputationPoints(value);
     });
     reputation_point_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+    
+    // Edit oxygen.
+    (new GuiLabel(left_col, "", "Oxygen:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+
+    oxygen_point_slider = new GuiSlider(left_col, "", 0.0, 100.0, 0.0, [this](float value) {
+        target->setOxygenPoints(value);
+    });
+    oxygen_point_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
     // Edit energy level.
     (new GuiLabel(left_col, "", "Max energy:", 30))->setSize(GuiElement::GuiSizeMax, 50);
@@ -578,6 +586,13 @@ GuiShipTweakPlayer::GuiShipTweakPlayer(GuiContainer* owner)
         target->energy_level = std::min(value, target->max_energy_level);
     });
     energy_level_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
+    
+    (new GuiLabel(left_col, "", "Number of repair teams:", 30))->setSize(GuiElement::GuiSizeMax, 50);
+
+    repair_team_slider = new GuiSlider(left_col, "", 0.0, 2000, 0.0, [this](float value) {
+        target->setRepairCrewCount(value);
+    });
+    repair_team_slider->addOverlay()->setSize(GuiElement::GuiSizeMax, 40);
 
     // Display Boost/Strafe speed sliders
     (new GuiLabel(left_col, "", "Boost Speed:", 30))->setSize(GuiElement::GuiSizeMax, 50);
@@ -635,6 +650,10 @@ void GuiShipTweakPlayer::onDraw(sf::RenderTarget& window)
 
     // Update reputation points.
     reputation_point_slider->setValue(target->getReputationPoints());
+    // Update repair team number.
+    repair_team_slider->setValue(target->getRepairCrewCount());
+    // Update oxygen points.
+    oxygen_point_slider->setValue(target->getOxygenPoints());
 }
 
 void GuiShipTweakPlayer::open(P<SpaceObject> target)

--- a/src/screens/gm/tweak.h
+++ b/src/screens/gm/tweak.h
@@ -163,10 +163,12 @@ private:
 
     GuiTextEntry* control_code;
     GuiSlider* reputation_point_slider;
+    GuiSlider* oxygen_point_slider;
     GuiSlider* energy_level_slider;
     GuiSlider* max_energy_level_slider;
     GuiSlider* combat_maneuver_boost_speed_slider;
     GuiSlider* combat_maneuver_strafe_speed_slider;
+    GuiSlider* repair_team_slider;
     GuiLabel* position_count;
     GuiKeyValueDisplay* position[max_crew_positions];
 public:

--- a/src/screens/mainScreen.cpp
+++ b/src/screens/mainScreen.cpp
@@ -14,6 +14,8 @@
 #include "screenComponents/radarView.h"
 #include "screenComponents/shipDestroyedPopup.h"
 
+#include "screens/extra/damcon.h"
+
 #include "gui/gui2_overlay.h"
 
 ScreenMainScreen::ScreenMainScreen()
@@ -33,9 +35,20 @@ ScreenMainScreen::ScreenMainScreen()
     long_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     long_range_radar->setRangeIndicatorStepSize(5000.0f)->longRange()->enableCallsigns()->hide();
     long_range_radar->setFogOfWarStyle(GuiRadarView::NebulaFogOfWar);
+
+    global_range_radar = new GuiRadarView(this, "GLOBAL", 50000.0f, nullptr);
+    global_range_radar->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    global_range_radar->setAutoCentering(true);
+    global_range_radar->longRange()->enableWaypoints()->enableCallsigns()->setStyle(GuiRadarView::Rectangular)->setFogOfWarStyle(GuiRadarView::FriendlysShortRangeFogOfWar);
+    global_range_radar->hide();
+        
     onscreen_comms = new GuiCommsOverlay(this);
     onscreen_comms->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax)->setVisible(false);
-
+    
+    ship_state = new DamageControlScreen(this);
+    ship_state->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
+    ship_state->hide();
+    
     new GuiShipDestroyedPopup(this);
     
     new GuiJumpIndicator(this);
@@ -130,16 +143,36 @@ void ScreenMainScreen::update(float delta)
             viewport->show();
             tactical_radar->hide();
             long_range_radar->hide();
+            global_range_radar->hide();
+            ship_state->hide();
             break;
         case MSS_Tactical:
             viewport->hide();
             tactical_radar->show();
             long_range_radar->hide();
+            global_range_radar->hide();
+            ship_state->hide();
             break;
         case MSS_LongRange:
             viewport->hide();
             tactical_radar->hide();
             long_range_radar->show();
+            global_range_radar->hide();
+            ship_state->hide();
+            break;
+        case MSS_GlobalRange:
+            viewport->hide();
+            tactical_radar->hide();
+            long_range_radar->hide();
+            global_range_radar->show();
+            ship_state->hide();
+            break;
+        case MSS_ShipState:
+            viewport->hide();
+            tactical_radar->hide();
+            long_range_radar->hide();
+            global_range_radar->hide();
+            ship_state->show();
             break;
         }
 
@@ -217,14 +250,42 @@ void ScreenMainScreen::onClick(sf::Vector2f mouse_position)
                 my_spaceship->commandMainScreenSetting(MSS_Tactical);
             else if (gameGlobalInfo->allow_main_screen_long_range_radar)
                 my_spaceship->commandMainScreenSetting(MSS_LongRange);
+            else if (gameGlobalInfo->allow_main_screen_global_range_radar)
+                my_spaceship->commandMainScreenSetting(MSS_GlobalRange);
+            else if (gameGlobalInfo->allow_main_screen_ship_state)
+                my_spaceship->commandMainScreenSetting(MSS_ShipState);
             break;
         case MSS_Tactical:
             if (gameGlobalInfo->allow_main_screen_long_range_radar)
                 my_spaceship->commandMainScreenSetting(MSS_LongRange);
+            else if (gameGlobalInfo->allow_main_screen_global_range_radar)
+                my_spaceship->commandMainScreenSetting(MSS_GlobalRange);
+            else if (gameGlobalInfo->allow_main_screen_ship_state)
+                my_spaceship->commandMainScreenSetting(MSS_ShipState);
             break;
         case MSS_LongRange:
+            if (gameGlobalInfo->allow_main_screen_global_range_radar)
+                my_spaceship->commandMainScreenSetting(MSS_GlobalRange);
+            else if (gameGlobalInfo->allow_main_screen_ship_state)
+                my_spaceship->commandMainScreenSetting(MSS_ShipState);
+            else if (gameGlobalInfo->allow_main_screen_tactical_radar)
+                my_spaceship->commandMainScreenSetting(MSS_Tactical);
+            break;
+        case MSS_GlobalRange:
+            if (gameGlobalInfo->allow_main_screen_ship_state)
+                my_spaceship->commandMainScreenSetting(MSS_ShipState);
+            else if (gameGlobalInfo->allow_main_screen_tactical_radar)
+                my_spaceship->commandMainScreenSetting(MSS_Tactical);
+            else if (gameGlobalInfo->allow_main_screen_long_range_radar)
+                my_spaceship->commandMainScreenSetting(MSS_LongRange);
+            break;
+        case MSS_ShipState:
             if (gameGlobalInfo->allow_main_screen_tactical_radar)
                 my_spaceship->commandMainScreenSetting(MSS_Tactical);
+            else if (gameGlobalInfo->allow_main_screen_long_range_radar)
+                my_spaceship->commandMainScreenSetting(MSS_LongRange);
+            else if (gameGlobalInfo->allow_main_screen_global_range_radar)
+                my_spaceship->commandMainScreenSetting(MSS_GlobalRange);
             break;
         }
     }

--- a/src/screens/mainScreen.h
+++ b/src/screens/mainScreen.h
@@ -8,6 +8,8 @@
 class GuiViewport3D;
 class GuiRadarView;
 class GuiCommsOverlay;
+class DamageControlScreen;
+class RelayScreen;
 
 class ScreenMainScreen : public GuiCanvas, public Updatable
 {
@@ -16,9 +18,11 @@ private:
     GuiViewport3D* viewport;
     GuiRadarView* tactical_radar;
     GuiRadarView* long_range_radar;
+    GuiRadarView* global_range_radar;
     bool first_person;
     GuiCommsOverlay* onscreen_comms;
     int impulse_sound = -1;
+    DamageControlScreen*ship_state ;
 public:
     ScreenMainScreen();
     

--- a/src/screens/windowScreen.cpp
+++ b/src/screens/windowScreen.cpp
@@ -12,7 +12,8 @@ WindowScreen::WindowScreen(float angle)
 : angle(angle)
 {
     viewport = new GuiViewport3D(this, "VIEWPORT");
-    viewport->showCallsigns()->showHeadings()->showSpacedust();
+    // viewport->showCallsigns()->showHeadings()->showSpacedust();
+    viewport->showSpacedust();
     viewport->setPosition(0, 0, ATopLeft)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 
     new GuiShipDestroyedPopup(this);
@@ -40,6 +41,8 @@ void WindowScreen::update(float delta)
         camera_position.x = position.x;
         camera_position.y = position.y;
         camera_position.z = 0.0;
+        
+        my_spaceship->draw3DTransparent();
     }
 }
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -187,8 +187,8 @@ string alertLevelToString(EAlertLevel level)
 }
 
 // Configure ship's log packets.
-static inline sf::Packet& operator << (sf::Packet& packet, const PlayerSpaceship::ShipLogEntry& e) { return packet << e.prefix << e.text << e.color.r << e.color.g << e.color.b << e.color.a; }
-static inline sf::Packet& operator >> (sf::Packet& packet, PlayerSpaceship::ShipLogEntry& e) { packet >> e.prefix >> e.text >> e.color.r >> e.color.g >> e.color.b >> e.color.a; return packet; }
+static inline sf::Packet& operator << (sf::Packet& packet, const PlayerSpaceship::ShipLogEntry& e) { return packet << e.prefix << e.text << e.color.r << e.color.g << e.color.b << e.color.a << e.station; }
+static inline sf::Packet& operator >> (sf::Packet& packet, PlayerSpaceship::ShipLogEntry& e) { packet >> e.prefix >> e.text >> e.color.r >> e.color.g >> e.color.b >> e.color.a >> e.station; return packet; }
 
 REGISTER_MULTIPLAYER_CLASS(PlayerSpaceship, "PlayerSpaceship");
 PlayerSpaceship::PlayerSpaceship()
@@ -214,6 +214,7 @@ PlayerSpaceship::PlayerSpaceship()
     scan_probe_recharge = 0.0;
     alert_level = AL_Normal;
     shields_active = false;
+    warp_indicator = 0;
     control_code = "";
 
     setFactionId(1);
@@ -242,7 +243,8 @@ PlayerSpaceship::PlayerSpaceship()
     registerMemberReplication(&comms_reply_message);
     registerMemberReplication(&comms_target_name);
     registerMemberReplication(&comms_incomming_message);
-    registerMemberReplication(&ships_log);
+    registerMemberReplication(&ships_log_extern);
+    registerMemberReplication(&ships_log_intern);
     registerMemberReplication(&waypoints);
     registerMemberReplication(&scan_probe_stock);
     registerMemberReplication(&activate_self_destruct);
@@ -294,7 +296,8 @@ PlayerSpaceship::PlayerSpaceship()
     setCallSign("PL" + string(getMultiplayerId()));
 
     // Initialize the ship's log.
-    addToShipLog("Start of log", colorConfig.log_generic);
+    addToShipLog("Start of extern log", colorConfig.log_generic,"extern");
+    addToShipLog("Start of intern log", colorConfig.log_generic,"intern");
 }
 
 void PlayerSpaceship::update(float delta)
@@ -495,6 +498,15 @@ void PlayerSpaceship::update(float delta)
             if (!useEnergy(energy_warp_per_second * delta * powf(warp_request, 1.2f) * (shields_active ? 1.5 : 1.0)))
                 // If there's not enough energy, fall out of warp.
                 warp_request = 0;
+                
+            for(float n=0; n<=4; n++)
+            {
+                if ((current_warp > n-0.1 && current_warp < n+0.1) && warp_indicator != n)
+                {
+                    warp_indicator = n;
+                    addToShipLog("WARP " + string(abs(n)), sf::Color::White,"intern");
+                }
+            }
         }
 
         if (scanning_target)
@@ -627,9 +639,24 @@ void PlayerSpaceship::takeHullDamage(float damage_amount, DamageInfo& info)
     {
         hull_damage_indicator = 1.5;
     }
+    
+    float systems_diff[SYS_COUNT];
+    for(int n=0; n<SYS_COUNT; n++)
+    {
+        systems_diff[n] = systems[n].health;
+    }
 
     // Take hull damage like any other ship.
     SpaceShip::takeHullDamage(damage_amount, info);
+    
+    // Infos for log intern
+    string system_damage = string(abs(damage_amount)) + string(" damages to hull. System affected : ");
+    for(int n=0; n<SYS_COUNT; n++)
+    {
+        if(systems_diff[n] != systems[n].health)
+            system_damage = system_damage + string(getSystemName(ESystem(n))) + string(" ");
+    }
+    addToShipLog(system_damage,sf::Color::Red,"intern");
 }
 
 void PlayerSpaceship::setSystemCoolantRequest(ESystem system, float request)
@@ -780,15 +807,20 @@ void PlayerSpaceship::setRepairCrewCount(int amount)
     }
 }
 
-void PlayerSpaceship::addToShipLog(string message, sf::Color color)
+void PlayerSpaceship::addToShipLog(string message, sf::Color color, string station = "extern")
 {
-    // Cap the ship's log size to 100 entries. If it exceeds that limit,
-    // start erasing entries from the beginning.
-    if (ships_log.size() > 100)
-        ships_log.erase(ships_log.begin());
-
-    // Timestamp a log entry, color it, and add it to the end of the log.
-    ships_log.emplace_back(string(engine->getElapsedTime(), 1) + string(": "), message, color);
+    if (station == "extern")
+    {
+        if (ships_log_extern.size() > 100)
+            ships_log_extern.erase(ships_log_extern.begin());
+        ships_log_extern.emplace_back(string(engine->getElapsedTime(), 1) + string(": "), message, color, station);
+    }
+    else if (station == "intern")
+    {
+        if (ships_log_intern.size() > 100)
+            ships_log_intern.erase(ships_log_intern.begin());
+        ships_log_intern.emplace_back(string(engine->getElapsedTime(), 1) + string(": "), message, color, station);
+    }
 }
 
 void PlayerSpaceship::addToShipLogBy(string message, P<SpaceObject> target)
@@ -805,10 +837,13 @@ void PlayerSpaceship::addToShipLogBy(string message, P<SpaceObject> target)
         addToShipLog(message, colorConfig.log_receive_neutral);
 }
 
-const std::vector<PlayerSpaceship::ShipLogEntry>& PlayerSpaceship::getShipsLog() const
+const std::vector<PlayerSpaceship::ShipLogEntry>& PlayerSpaceship::getShipsLog(string station) const
 {
     // Return the ship's log.
-    return ships_log;
+    if (station == "extern")
+        return ships_log_extern;
+    if (station == "intern")
+        return ships_log_intern;
 }
 
 void PlayerSpaceship::transferPlayersToShip(P<PlayerSpaceship> other_ship)
@@ -1052,11 +1087,14 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
             float distance;
             packet >> distance;
             initializeJump(distance);
+            addToShipLog("Jump Initialisation",sf::Color::White,"intern");
         }
         break;
     case CMD_SET_TARGET:
         {
             packet >> target_id;
+            if (target_id != int32_t(-1))
+                addToShipLog("Target activated : " + string(SpaceShip::getTarget()->SpaceObject::getCallSign()),sf::Color::Yellow,"intern");
         }
         break;
     case CMD_LOAD_TUBE:
@@ -1087,7 +1125,10 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
             packet >> tube_nr >> missile_target_angle;
 
             if (tube_nr >= 0 && tube_nr < max_weapon_tubes)
+            {
                 weapon_tube[tube_nr].fire(missile_target_angle);
+                addToShipLog("Missile fire",sf::Color::Yellow,"intern");
+            }
         }
         break;
     case CMD_SET_SHIELDS:
@@ -1100,11 +1141,13 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
                 shields_active = active;
                 if (active)
                 {
-                    playSoundOnMainScreen("shield_up.wav");
+                    soundManager->playSound("shield_up.wav");
+                    addToShipLog("Shields on",sf::Color::Green,"intern");
                 }
                 else
                 {
-                    playSoundOnMainScreen("shield_down.wav");
+                    soundManager->playSound("shield_down.wav");
+                    addToShipLog("Shields off",sf::Color::Green,"intern");
                 }
             }
         }
@@ -1166,13 +1209,20 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
             int32_t id;
             packet >> id;
             requestDock(game_server->getObjectById(id));
+            addToShipLog("Docking requested",sf::Color::Cyan,"intern");
         }
         break;
     case CMD_UNDOCK:
-        requestUndock();
+        {
+            requestUndock();
+            addToShipLog("Undocking requested",sf::Color::Cyan,"intern");
+        }
         break;
     case CMD_ABORT_DOCK:
-        abortDock();
+        {
+            abortDock();
+            addToShipLog("Docking aborded",sf::Color::Cyan,"intern");
+        }
         break;
     case CMD_OPEN_TEXT_COMM:
         if (comms_state == CS_Inactive || comms_state == CS_BeingHailed || comms_state == CS_BeingHailedByGM || comms_state == CS_ChannelClosed)
@@ -1300,7 +1350,10 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
         }
         break;
     case CMD_SET_AUTO_REPAIR:
-        packet >> auto_repair_enabled;
+        {
+            packet >> auto_repair_enabled;
+            addToShipLog("Auto repair enabled",sf::Color::White,"intern");
+        }
         break;
     case CMD_SET_BEAM_FREQUENCY:
         {
@@ -1311,6 +1364,7 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
                 beam_frequency = 0;
             if (beam_frequency > SpaceShip::max_frequency)
                 beam_frequency = SpaceShip::max_frequency;
+            addToShipLog("Beam frequency changed : " + frequencyToString(new_frequency),sf::Color::Yellow,"intern");
         }
         break;
     case CMD_SET_BEAM_SYSTEM_TARGET:
@@ -1322,6 +1376,7 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
                 beam_system_target = SYS_None;
             if (beam_system_target > ESystem(int(SYS_COUNT) - 1))
                 beam_system_target = ESystem(int(SYS_COUNT) - 1);
+            addToShipLog("Beam system target changed : " + getSystemName(system),sf::Color::Yellow,"intern");
         }
         break;
     case CMD_SET_SHIELD_FREQUENCY:
@@ -1338,6 +1393,7 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
                     shield_frequency = 0;
                 if (shield_frequency > SpaceShip::max_frequency)
                     shield_frequency = SpaceShip::max_frequency;
+                addToShipLog("Shields frequency changed : " + frequencyToString(new_frequency),sf::Color::Green,"intern");
             }
         }
         break;
@@ -1368,6 +1424,7 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
         break;
     case CMD_ACTIVATE_SELF_DESTRUCT:
         activate_self_destruct = true;
+        addToShipLog("Auto destruction activated",sf::Color::Red,"intern");
         for(int n=0; n<max_self_destruct_codes; n++)
         {
             self_destruct_code[n] = irandom(0, 99999);
@@ -1396,6 +1453,7 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
         if (self_destruct_countdown <= 0.0f)
         {
             activate_self_destruct = false;
+            addToShipLog("Auto destruction canceled",sf::Color::Red,"intern");
         }
         break;
     case CMD_CONFIRM_SELF_DESTRUCT:
@@ -1438,6 +1496,10 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
     case CMD_SET_ALERT_LEVEL:
         {
             packet >> alert_level;
+            if(alertLevelToString(alert_level) == "RED ALERT")
+                addToShipLog("RED ALERT",sf::Color::Red,"intern");
+            if(alertLevelToString(alert_level) == "YELLOW ALERT")
+                addToShipLog("YELLOW ALERT",sf::Color::Yellow,"intern");
         }
         break;
     case CMD_SET_SCIENCE_LINK:

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -61,12 +61,13 @@ public:
         string prefix;
         string text;
         sf::Color color;
+        string station;
 
         ShipLogEntry() {}
-        ShipLogEntry(string prefix, string text, sf::Color color)
-        : prefix(prefix), text(text), color(color) {}
+        ShipLogEntry(string prefix, string text, sf::Color color, string station)
+        : prefix(prefix), text(text), color(color), station(station) {}
 
-        bool operator!=(const ShipLogEntry& e) { return prefix != e.prefix || text != e.text || color != e.color; }
+        bool operator!=(const ShipLogEntry& e) { return prefix != e.prefix || text != e.text || color != e.color || station != e.station; }
     };
     
     class CustomShipFunction
@@ -106,6 +107,7 @@ public:
     bool auto_coolant_enabled;
     // Whether shields are up (true) or down
     bool shields_active;
+    int warp_indicator;
     // Password to join a ship. Default is empty.
     string control_code;
 
@@ -120,10 +122,11 @@ private:
     P<SpaceObject> comms_target; // Server only
     std::vector<int> comms_reply_id;
     std::vector<string> comms_reply_message;
-    CommsScriptInterface comms_script_interface; // Server only
+    CommsScriptInterface comms_script_interface;  //Server only
     // Ship's log container
-    std::vector<ShipLogEntry> ships_log;
-    
+    std::vector<ShipLogEntry> ships_log_extern;
+    std::vector<ShipLogEntry> ships_log_intern;
+
 public:
     std::vector<CustomShipFunction> custom_functions;
 
@@ -263,9 +266,9 @@ public:
     float getNetSystemEnergyUsage();
 
     // Ship's log functions
-    void addToShipLog(string message, sf::Color color);
+    void addToShipLog(string message, sf::Color color, string station);
     void addToShipLogBy(string message, P<SpaceObject> target);
-    const std::vector<ShipLogEntry>& getShipsLog() const;
+    const std::vector<ShipLogEntry>& getShipsLog(string station) const;
 
     // Ship's crew functions
     void transferPlayersToShip(P<PlayerSpaceship> other_ship);

--- a/src/spaceObjects/spaceObject.cpp
+++ b/src/spaceObjects/spaceObject.cpp
@@ -52,6 +52,17 @@ REGISTER_SCRIPT_CLASS_NO_CREATE(SpaceObject)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, takeReputationPoints);
     /// Add a certain amount of reputation points.
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, addReputationPoints);
+    /// Sets the oxygen to a value.
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, setOxygenPoints);
+    /// Return the current amount of oxygen points.
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getOxygenPoints);
+    /// Take a certain amount of oxygen points, returns true when there are enough points to take. Returns false when there are not enough points and does not lower the points.
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, takeOxygenPoints);
+    /// Add a certain amount of Oxygen points.
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, addOxygenPoints);
+    /// Remove a certain amount of Oxygen points.
+    REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject,removeOxygenPoints);
+    
     /// Get the name of the sector this object is in (A4 for example)
     REGISTER_SCRIPT_CLASS_FUNCTION(SpaceObject, getSectorName);
     /// Hail a player ship from this object. The ship will get a notification and can accept or deny the hail.
@@ -104,12 +115,15 @@ SpaceObject::SpaceObject(float collision_range, string multiplayer_name, float m
     object_radius = collision_range;
     space_object_list.push_back(this);
     faction_id = 0;
+    
+    oxygen_points = 100;
 
     scanning_complexity_value = 0;
     scanning_depth_value = 0;
 
     registerMemberReplication(&callsign);
     registerMemberReplication(&faction_id);
+    registerMemberReplication(&oxygen_points);
     registerMemberReplication(&scanned_by_faction);
     registerMemberReplication(&object_description.not_scanned);
     registerMemberReplication(&object_description.friend_of_foe_identified);
@@ -366,6 +380,36 @@ void SpaceObject::addReputationPoints(float amount)
     gameGlobalInfo->reputation_points[faction_id] += amount;
     if (gameGlobalInfo->reputation_points[faction_id] < 0.0)
         gameGlobalInfo->reputation_points[faction_id] = 0.0;
+}
+
+void SpaceObject::setOxygenPoints(float amount)
+{
+    oxygen_points = amount;
+}
+
+int SpaceObject::getOxygenPoints()
+{
+    return oxygen_points;
+}
+
+bool SpaceObject::takeOxygenPoints(float amount)
+{
+	if (oxygen_points < amount)
+		return false;
+	oxygen_points -= amount;
+    	return true;
+}
+
+void SpaceObject::removeOxygenPoints(float amount)
+{
+    addOxygenPoints(-amount);
+}
+
+void SpaceObject::addOxygenPoints(float amount)
+{
+    oxygen_points += amount;
+    if (oxygen_points < 0.0)
+    	oxygen_points = 0.0;
 }
 
 string SpaceObject::getSectorName()

--- a/src/spaceObjects/spaceObject.h
+++ b/src/spaceObjects/spaceObject.h
@@ -105,6 +105,7 @@ public:
     int scanning_complexity_value;
     int scanning_depth_value;
     string callsign;
+    int oxygen_points;
 
     SpaceObject(float collisionRange, string multiplayerName, float multiplayer_significant_range=-1);
 
@@ -210,6 +211,11 @@ public:
     bool takeReputationPoints(float amount);
     void removeReputationPoints(float amount);
     void addReputationPoints(float amount);
+    void setOxygenPoints(float amount);
+    int getOxygenPoints();
+    bool takeOxygenPoints(float amount);
+    void removeOxygenPoints(float amount);
+    void addOxygenPoints(float amount);
     void setCommsScript(string script_name) { this->comms_script_name = script_name; this->comms_script_callback.clear(); }
     void setCommsFunction(ScriptSimpleCallback callback) { this->comms_script_name = ""; this->comms_script_callback = callback; }
     bool areEnemiesInRange(float range);

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -1123,7 +1123,7 @@ void SpaceShip::addBroadcast(int threshold, string message)
 
             if (addtolog)
             {
-                ship->addToShipLog(message, color);
+                ship->addToShipLog(message, color, "extern");
             }
         }
     }

--- a/src/spaceObjects/spaceship.h
+++ b/src/spaceObjects/spaceship.h
@@ -14,7 +14,9 @@ enum EMainScreenSetting
     MSS_Right,
     MSS_Target,
     MSS_Tactical,
-    MSS_LongRange
+    MSS_LongRange,
+    MSS_GlobalRange,
+    MSS_ShipState
 };
 template<> void convert<EMainScreenSetting>::param(lua_State* L, int& idx, EMainScreenSetting& mss);
 

--- a/src/spaceObjects/spaceship.hpp
+++ b/src/spaceObjects/spaceship.hpp
@@ -18,6 +18,10 @@ template<> void convert<EMainScreenSetting>::param(lua_State* L, int& idx, EMain
         mss = MSS_Tactical;
     else if (str == "longrange")
         mss = MSS_LongRange;
+    else if (str == "globalrange")
+        mss = MSS_GlobalRange;
+    else if (str == "shipstate")
+        mss = MSS_ShipState;
     else
         mss = MSS_Front;
 }

--- a/src/tutorialGame.cpp
+++ b/src/tutorialGame.cpp
@@ -33,6 +33,8 @@ REGISTER_SCRIPT_CLASS_NO_CREATE(TutorialGame)
     REGISTER_SCRIPT_CLASS_FUNCTION(TutorialGame, switchViewToLongRange);
     REGISTER_SCRIPT_CLASS_FUNCTION(TutorialGame, switchViewToScreen);
     REGISTER_SCRIPT_CLASS_FUNCTION(TutorialGame, showMessage);
+    REGISTER_SCRIPT_CLASS_FUNCTION(TutorialGame, showLittleMessage);
+    REGISTER_SCRIPT_CLASS_FUNCTION(TutorialGame, hideMessage);
     REGISTER_SCRIPT_CLASS_FUNCTION(TutorialGame, setMessageToTopPosition);
     REGISTER_SCRIPT_CLASS_FUNCTION(TutorialGame, setMessageToBottomPosition);
     REGISTER_SCRIPT_CLASS_FUNCTION(TutorialGame, onNext);
@@ -164,6 +166,32 @@ void TutorialGame::showMessage(string message, bool show_next)
         next_button->hide();
         frame->setSize(900, 200);
     }
+}
+
+void TutorialGame::showLittleMessage(string message, bool show_next)
+{
+    if (viewport == nullptr)
+    return;
+    
+    frame->show();
+    text->setText(message)->setSize(900 - 40, 50 - 40);
+    if (show_next)
+    {
+        next_button->show();
+        frame->setSize(900, 80);
+    }
+    else
+    {
+        next_button->hide();
+        frame->setSize(900, 50);
+    }
+}
+
+void TutorialGame::hideMessage()
+{
+    if (viewport == nullptr)
+        return;
+	frame->hide();
 }
 
 void TutorialGame::switchViewToMainScreen()

--- a/src/tutorialGame.h
+++ b/src/tutorialGame.h
@@ -34,6 +34,8 @@ public:
     void setPlayerShip(P<PlayerSpaceship> ship);
 
     void showMessage(string message, bool show_next);
+    void showLittleMessage(string message, bool show_next);
+    void hideMessage();
     void switchViewToMainScreen();
     void switchViewToTactical();
     void switchViewToLongRange();


### PR DESCRIPTION
> I propose to add a intern log only seen by the engeneer, to display all intern modifications of the ship. I use it to inform the ship about a virus attack, or some ship failures.
> 
> * I change the function addToShipLog to addToShipLog(string message, sf::Color color, **string station**). If the value of the station is "extern", the extern log (for the relay) is filled. If "intern", the intern log (for the engeneer) is filled.
> * By default, the value of the station is "extern". So this PR don't affect the current code
> 
> Some automatic informations fill the log with this color code :
> 
> Green :
> shields enabled or disabled
> Change of the shields frequency
> 
> Yellow :
> Missile fire
> Change of the beam system target
> Change of the beam frequence
> target activated
> 
> yellow alert
> 
> White :
> warp speed
> jump initialisation
> 
> Red :
> damage received
> red alert
> auto destruction situation
> 
> Cyan :
> docking situation
> 
> This PR don't use the new color system, because I don't understand it now :)
> 
> PS : I have this warning during compilation :
> 
> ```
> /home/thomas/EE/EmptyEpsilon/src/spaceObjects/playerSpaceship.cpp:` In member function ‘const std::vector<PlayerSpaceship::ShipLogEntry>& PlayerSpaceship::getShipsLog(string) const’:
> /home/thomas/EE/EmptyEpsilon/src/spaceObjects/playerSpaceship.cpp:667:1: warning: control reaches end of non-void function [-Wreturn-type]
>  }
> ```

