### PR TITLE
Intern (engineering) log feature from tdelc

### DIFF
--- a/src/screenComponents/shipsLogControl.cpp
+++ b/src/screenComponents/shipsLogControl.cpp
@@ -5,8 +5,8 @@
 #include "gui/gui2_panel.h"
 #include "gui/gui2_advancedscrolltext.h"
 
-ShipsLog::ShipsLog(GuiContainer* owner)
-: GuiElement(owner, "")
+ShipsLog::ShipsLog(GuiContainer* owner, string station)
+: GuiElement(owner, ""), station(station)
 {
     setPosition(0, 0, ABottomCenter);
     setSize(GuiElement::GuiSizeMax, 50);
@@ -26,11 +26,11 @@ void ShipsLog::onDraw(sf::RenderTarget& window)
     if (!my_spaceship)
         return;
 
-    const std::vector<PlayerSpaceship::ShipLogEntry>& logs = my_spaceship->getShipsLog();
+    const std::vector<PlayerSpaceship::ShipLogEntry>& logs = my_spaceship->getShipsLog(station);
     
     if (open)
     {
-        const std::vector<PlayerSpaceship::ShipLogEntry>& logs = my_spaceship->getShipsLog();
+        const std::vector<PlayerSpaceship::ShipLogEntry>& logs = my_spaceship->getShipsLog(station);
         if (log_text->getEntryCount() > 0 && logs.size() == 0)
             log_text->clearEntries();
 

--- a/src/screenComponents/shipsLogControl.h
+++ b/src/screenComponents/shipsLogControl.h
@@ -9,7 +9,8 @@ class GuiAdvancedScrollText;
 class ShipsLog : public GuiElement
 {
 public:
-    ShipsLog(GuiContainer* owner);
+    string station;
+    ShipsLog(GuiContainer* owner, string station);
 
     virtual void onDraw(sf::RenderTarget& window) override;
     virtual bool onMouseDown(sf::Vector2f position) override;

--- a/src/screens/crew4/operationsScreen.cpp
+++ b/src/screens/crew4/operationsScreen.cpp
@@ -76,6 +76,6 @@ OperationScreen::OperationScreen(GuiContainer* owner)
     
     mode = TargetSelection;
     
-    new ShipsLog(this);
+    new ShipsLog(this,"extern");
     (new GuiCommsOverlay(this))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 }

--- a/src/screens/crew6/engineeringScreen.cpp
+++ b/src/screens/crew6/engineeringScreen.cpp
@@ -6,6 +6,7 @@
 #include "screenComponents/selfDestructButton.h"
 #include "screenComponents/alertOverlay.h"
 #include "screenComponents/customShipFunctions.h"
+#include "screenComponents/shipsLogControl.h"
 
 #include "gui/gui2_keyvaluedisplay.h"
 #include "gui/gui2_autolayout.h"
@@ -38,7 +39,7 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
     (new GuiSelfDestructButton(this, "SELF_DESTRUCT"))->setPosition(20, 260, ATopLeft)->setSize(240, 100);
 
     GuiElement* system_config_container = new GuiElement(this, "");
-    system_config_container->setPosition(0, -20, ABottomCenter)->setSize(750 + 300, GuiElement::GuiSizeMax);
+    system_config_container->setPosition(0, -50, ABottomCenter)->setSize(750 + 300, GuiElement::GuiSizeMax);
     GuiAutoLayout* system_row_layouts = new GuiAutoLayout(system_config_container, "SYSTEM_ROWS", GuiAutoLayout::LayoutVerticalBottomToTop);
     system_row_layouts->setPosition(0, 0, ABottomLeft);
     system_row_layouts->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
@@ -117,6 +118,8 @@ EngineeringScreen::EngineeringScreen(GuiContainer* owner, ECrewPosition crew_pos
     for(float snap_point = 0.0; snap_point <= 10.0; snap_point += 2.5)
         coolant_slider->addSnapValue(snap_point, 0.1);
     coolant_slider->disable();
+    
+    new ShipsLog(this,"intern");
 
     (new GuiShipInternalView(system_row_layouts, "SHIP_INTERNAL_VIEW", 48.0f))->setShip(my_spaceship)->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
     

--- a/src/screens/crew6/relayScreen.cpp
+++ b/src/screens/crew6/relayScreen.cpp
@@ -200,8 +200,7 @@ RelayScreen::RelayScreen(GuiContainer* owner)
 
     hacking_dialog = new GuiHackingDialog(this, "");
 
-    new ShipsLog(this);
-
+    new ShipsLog(this,"extern");
     (new GuiCommsOverlay(this))->setSize(GuiElement::GuiSizeMax, GuiElement::GuiSizeMax);
 }
 

--- a/src/screens/extra/shipLogScreen.cpp
+++ b/src/screens/extra/shipLogScreen.cpp
@@ -20,7 +20,7 @@ void ShipLogScreen::onDraw(sf::RenderTarget& window)
     
     if (my_spaceship)
     {
-        const std::vector<PlayerSpaceship::ShipLogEntry>& logs = my_spaceship->getShipsLog();
+        const std::vector<PlayerSpaceship::ShipLogEntry>& logs = my_spaceship->getShipsLog("extern");
         if (log_text->getEntryCount() > 0 && logs.size() == 0)
             log_text->clearEntries();
 

--- a/src/spaceObjects/playerSpaceship.cpp
+++ b/src/spaceObjects/playerSpaceship.cpp
@@ -187,8 +187,8 @@ string alertLevelToString(EAlertLevel level)
 }
 
 // Configure ship's log packets.
-static inline sf::Packet& operator << (sf::Packet& packet, const PlayerSpaceship::ShipLogEntry& e) { return packet << e.prefix << e.text << e.color.r << e.color.g << e.color.b << e.color.a; }
-static inline sf::Packet& operator >> (sf::Packet& packet, PlayerSpaceship::ShipLogEntry& e) { packet >> e.prefix >> e.text >> e.color.r >> e.color.g >> e.color.b >> e.color.a; return packet; }
+static inline sf::Packet& operator << (sf::Packet& packet, const PlayerSpaceship::ShipLogEntry& e) { return packet << e.prefix << e.text << e.color.r << e.color.g << e.color.b << e.color.a << e.station; }
+static inline sf::Packet& operator >> (sf::Packet& packet, PlayerSpaceship::ShipLogEntry& e) { packet >> e.prefix >> e.text >> e.color.r >> e.color.g >> e.color.b >> e.color.a >> e.station; return packet; }
 
 REGISTER_MULTIPLAYER_CLASS(PlayerSpaceship, "PlayerSpaceship");
 PlayerSpaceship::PlayerSpaceship()
@@ -215,6 +215,7 @@ PlayerSpaceship::PlayerSpaceship()
     alert_level = AL_Normal;
     shields_active = false;
     control_code = "";
+    warp_indicator = 0;
 
     setFactionId(1);
 
@@ -242,7 +243,8 @@ PlayerSpaceship::PlayerSpaceship()
     registerMemberReplication(&comms_reply_message);
     registerMemberReplication(&comms_target_name);
     registerMemberReplication(&comms_incomming_message);
-    registerMemberReplication(&ships_log);
+    registerMemberReplication(&ships_log_extern);
+    registerMemberReplication(&ships_log_intern);
     registerMemberReplication(&waypoints);
     registerMemberReplication(&scan_probe_stock);
     registerMemberReplication(&activate_self_destruct);
@@ -293,8 +295,8 @@ PlayerSpaceship::PlayerSpaceship()
     // Initialize player ship callsigns with a "PL" designation.
     setCallSign("PL" + string(getMultiplayerId()));
 
-    // Initialize the ship's log.
-    addToShipLog("Start of log", colorConfig.log_generic);
+    addToShipLog("Start of extern log", colorConfig.log_generic,"extern");
+    addToShipLog("Start of intern log", colorConfig.log_generic,"intern");
 }
 
 void PlayerSpaceship::update(float delta)
@@ -495,6 +497,15 @@ void PlayerSpaceship::update(float delta)
             if (!useEnergy(energy_warp_per_second * delta * powf(warp_request, 1.2f) * (shields_active ? 1.5 : 1.0)))
                 // If there's not enough energy, fall out of warp.
                 warp_request = 0;
+                
+            for(float n=0; n<=4; n++)
+            {
+                if ((current_warp > n-0.1 && current_warp < n+0.1) && warp_indicator != n)
+                {
+                    warp_indicator = n;
+                    addToShipLog("WARP " + string(abs(n)), sf::Color::White,"intern");
+                }
+            }
         }
 
         if (scanning_target)
@@ -629,7 +640,22 @@ void PlayerSpaceship::takeHullDamage(float damage_amount, DamageInfo& info)
     }
 
     // Take hull damage like any other ship.
+    
+    float systems_diff[SYS_COUNT];
+    for(int n=0; n<SYS_COUNT; n++)
+    {
+        systems_diff[n] = systems[n].health;
+    }
     SpaceShip::takeHullDamage(damage_amount, info);
+    
+    // Infos for log intern
+    string system_damage = string(abs(damage_amount)) + string(" damages to hull. System affected : ");
+    for(int n=0; n<SYS_COUNT; n++)
+    {
+        if(systems_diff[n] != systems[n].health)
+            system_damage = system_damage + string(getSystemName(ESystem(n))) + string(" ");
+    }
+    addToShipLog(system_damage,sf::Color::Red,"intern");
 }
 
 void PlayerSpaceship::setSystemCoolantRequest(ESystem system, float request)
@@ -780,15 +806,24 @@ void PlayerSpaceship::setRepairCrewCount(int amount)
     }
 }
 
-void PlayerSpaceship::addToShipLog(string message, sf::Color color)
+void PlayerSpaceship::addToShipLog(string message, sf::Color color, string station = "extern")
 {
-    // Cap the ship's log size to 100 entries. If it exceeds that limit,
-    // start erasing entries from the beginning.
-    if (ships_log.size() > 100)
-        ships_log.erase(ships_log.begin());
-
-    // Timestamp a log entry, color it, and add it to the end of the log.
-    ships_log.emplace_back(string(engine->getElapsedTime(), 1) + string(": "), message, color);
+    // TODO: use getShipsLog()
+    if (station == "extern")
+    {
+        // Cap the ship's log size to 100 entries. If it exceeds that limit,
+        // start erasing entries from the beginning.
+        if (ships_log_extern.size() > 100)
+            ships_log_extern.erase(ships_log_extern.begin());
+        // Timestamp a log entry, color it, and add it to the end of the log.
+        ships_log_extern.emplace_back(string(engine->getElapsedTime(), 1) + string(": "), message, color, station);
+    }
+    else if (station == "intern")
+    {
+        if (ships_log_intern.size() > 100)
+            ships_log_intern.erase(ships_log_intern.begin());
+        ships_log_intern.emplace_back(string(engine->getElapsedTime(), 1) + string(": "), message, color, station);
+    }
 }
 
 void PlayerSpaceship::addToShipLogBy(string message, P<SpaceObject> target)
@@ -805,10 +840,12 @@ void PlayerSpaceship::addToShipLogBy(string message, P<SpaceObject> target)
         addToShipLog(message, colorConfig.log_receive_neutral);
 }
 
-const std::vector<PlayerSpaceship::ShipLogEntry>& PlayerSpaceship::getShipsLog() const
+const std::vector<PlayerSpaceship::ShipLogEntry>& PlayerSpaceship::getShipsLog(string station) const
 {
-    // Return the ship's log.
-    return ships_log;
+    if (station == "extern")
+        return ships_log_extern;
+    if (station == "intern")
+        return ships_log_intern;
 }
 
 void PlayerSpaceship::transferPlayersToShip(P<PlayerSpaceship> other_ship)
@@ -1052,11 +1089,14 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
             float distance;
             packet >> distance;
             initializeJump(distance);
+            addToShipLog("Jump Initialisation",sf::Color::White,"intern");
         }
         break;
     case CMD_SET_TARGET:
         {
             packet >> target_id;
+            if (target_id != int32_t(-1))
+                addToShipLog("Target activated : " + string(SpaceShip::getTarget()->SpaceObject::getCallSign()),sf::Color::Yellow,"intern");
         }
         break;
     case CMD_LOAD_TUBE:
@@ -1087,7 +1127,10 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
             packet >> tube_nr >> missile_target_angle;
 
             if (tube_nr >= 0 && tube_nr < max_weapon_tubes)
+            {
                 weapon_tube[tube_nr].fire(missile_target_angle);
+                addToShipLog("Missile fire",sf::Color::Yellow,"intern");
+            }
         }
         break;
     case CMD_SET_SHIELDS:
@@ -1100,11 +1143,13 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
                 shields_active = active;
                 if (active)
                 {
-                    playSoundOnMainScreen("shield_up.wav");
+                    soundManager->playSound("shield_up.wav");
+                    addToShipLog("Shields on",sf::Color::Green,"intern");
                 }
                 else
                 {
-                    playSoundOnMainScreen("shield_down.wav");
+                    soundManager->playSound("shield_down.wav");
+                    addToShipLog("Shields off",sf::Color::Green,"intern");
                 }
             }
         }
@@ -1166,13 +1211,20 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
             int32_t id;
             packet >> id;
             requestDock(game_server->getObjectById(id));
+            addToShipLog("Docking requested",sf::Color::Cyan,"intern");
         }
         break;
     case CMD_UNDOCK:
-        requestUndock();
+        {
+            requestUndock();
+            addToShipLog("Undocking requested",sf::Color::Cyan,"intern");
+        }
         break;
     case CMD_ABORT_DOCK:
-        abortDock();
+        {
+            abortDock();
+            addToShipLog("Docking aborded",sf::Color::Cyan,"intern");
+        }
         break;
     case CMD_OPEN_TEXT_COMM:
         if (comms_state == CS_Inactive || comms_state == CS_BeingHailed || comms_state == CS_BeingHailedByGM || comms_state == CS_ChannelClosed)
@@ -1300,7 +1352,10 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
         }
         break;
     case CMD_SET_AUTO_REPAIR:
-        packet >> auto_repair_enabled;
+        {
+            packet >> auto_repair_enabled;
+            addToShipLog("Auto repair enabled",sf::Color::White,"intern");
+        }
         break;
     case CMD_SET_BEAM_FREQUENCY:
         {
@@ -1311,6 +1366,7 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
                 beam_frequency = 0;
             if (beam_frequency > SpaceShip::max_frequency)
                 beam_frequency = SpaceShip::max_frequency;
+            addToShipLog("Beam frequency changed : " + frequencyToString(new_frequency),sf::Color::Yellow,"intern");
         }
         break;
     case CMD_SET_BEAM_SYSTEM_TARGET:
@@ -1322,6 +1378,7 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
                 beam_system_target = SYS_None;
             if (beam_system_target > ESystem(int(SYS_COUNT) - 1))
                 beam_system_target = ESystem(int(SYS_COUNT) - 1);
+            addToShipLog("Beam system target changed : " + getSystemName(system),sf::Color::Yellow,"intern");
         }
         break;
     case CMD_SET_SHIELD_FREQUENCY:
@@ -1338,6 +1395,7 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
                     shield_frequency = 0;
                 if (shield_frequency > SpaceShip::max_frequency)
                     shield_frequency = SpaceShip::max_frequency;
+                addToShipLog("Shields frequency changed : " + frequencyToString(new_frequency),sf::Color::Green,"intern");
             }
         }
         break;
@@ -1368,6 +1426,7 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
         break;
     case CMD_ACTIVATE_SELF_DESTRUCT:
         activate_self_destruct = true;
+        addToShipLog("Auto destruction activated",sf::Color::Red,"intern");
         for(int n=0; n<max_self_destruct_codes; n++)
         {
             self_destruct_code[n] = irandom(0, 99999);
@@ -1396,6 +1455,7 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
         if (self_destruct_countdown <= 0.0f)
         {
             activate_self_destruct = false;
+            addToShipLog("Auto destruction canceled",sf::Color::Red,"intern");
         }
         break;
     case CMD_CONFIRM_SELF_DESTRUCT:
@@ -1438,6 +1498,10 @@ void PlayerSpaceship::onReceiveClientCommand(int32_t client_id, sf::Packet& pack
     case CMD_SET_ALERT_LEVEL:
         {
             packet >> alert_level;
+            if(alertLevelToString(alert_level) == "RED ALERT")
+                addToShipLog("RED ALERT",sf::Color::Red,"intern");
+            if(alertLevelToString(alert_level) == "YELLOW ALERT")
+                addToShipLog("YELLOW ALERT",sf::Color::Yellow,"intern");
         }
         break;
     case CMD_SET_SCIENCE_LINK:

--- a/src/spaceObjects/playerSpaceship.h
+++ b/src/spaceObjects/playerSpaceship.h
@@ -61,12 +61,13 @@ public:
         string prefix;
         string text;
         sf::Color color;
+        string station;
 
         ShipLogEntry() {}
-        ShipLogEntry(string prefix, string text, sf::Color color)
-        : prefix(prefix), text(text), color(color) {}
+        ShipLogEntry(string prefix, string text, sf::Color color, string station)
+        : prefix(prefix), text(text), color(color), station(station) {}
 
-        bool operator!=(const ShipLogEntry& e) { return prefix != e.prefix || text != e.text || color != e.color; }
+        bool operator!=(const ShipLogEntry& e) { return prefix != e.prefix || text != e.text || color != e.color || station != e.station; }
     };
     
     class CustomShipFunction
@@ -108,6 +109,7 @@ public:
     bool shields_active;
     // Password to join a ship. Default is empty.
     string control_code;
+    int warp_indicator;
 
 private:
     // soundManager index of the shield object
@@ -120,10 +122,11 @@ private:
     P<SpaceObject> comms_target; // Server only
     std::vector<int> comms_reply_id;
     std::vector<string> comms_reply_message;
-    CommsScriptInterface comms_script_interface; // Server only
-    // Ship's log container
-    std::vector<ShipLogEntry> ships_log;
-    
+    CommsScriptInterface comms_script_interface;  //Server only
+
+    std::vector<ShipLogEntry> ships_log_extern;
+    std::vector<ShipLogEntry> ships_log_intern;
+
 public:
     std::vector<CustomShipFunction> custom_functions;
 
@@ -263,10 +266,10 @@ public:
     float getNetSystemEnergyUsage();
 
     // Ship's log functions
-    void addToShipLog(string message, sf::Color color);
+    void addToShipLog(string message, sf::Color color, string station);
     void addToShipLogBy(string message, P<SpaceObject> target);
-    const std::vector<ShipLogEntry>& getShipsLog() const;
-
+    const std::vector<ShipLogEntry>& getShipsLog(string station) const;
+    
     // Ship's crew functions
     void transferPlayersToShip(P<PlayerSpaceship> other_ship);
     void transferPlayersAtPositionToShip(ECrewPosition position, P<PlayerSpaceship> other_ship);

--- a/src/spaceObjects/spaceship.cpp
+++ b/src/spaceObjects/spaceship.cpp
@@ -1123,7 +1123,7 @@ void SpaceShip::addBroadcast(int threshold, string message)
 
             if (addtolog)
             {
-                ship->addToShipLog(message, color);
+                ship->addToShipLog(message, color, "extern");
             }
         }
     }


### PR DESCRIPTION
> I propose to add a intern log only seen by the engeneer, to display all intern modifications of the ship. I use it to inform the ship about a virus attack, or some ship failures.
> 
> * I change the function addToShipLog to addToShipLog(string message, sf::Color color, **string station**). If the value of the station is "extern", the extern log (for the relay) is filled. If "intern", the intern log (for the engeneer) is filled.
> * By default, the value of the station is "extern". So this PR don't affect the current code
> 
> Some automatic informations fill the log with this color code :
> 
> Green :
> shields enabled or disabled
> Change of the shields frequency
> 
> Yellow :
> Missile fire
> Change of the beam system target
> Change of the beam frequence
> target activated
> 
> yellow alert
> 
> White :
> warp speed
> jump initialisation
> 
> Red :
> damage received
> red alert
> auto destruction situation
> 
> Cyan :
> docking situation
> 
> This PR don't use the new color system, because I don't understand it now :)
> 
> PS : I have this warning during compilation :
> 
> ```
> /home/thomas/EE/EmptyEpsilon/src/spaceObjects/playerSpaceship.cpp:` In member function ‘const std::vector<PlayerSpaceship::ShipLogEntry>& PlayerSpaceship::getShipsLog(string) const’:
> /home/thomas/EE/EmptyEpsilon/src/spaceObjects/playerSpaceship.cpp:667:1: warning: control reaches end of non-void function [-Wreturn-type]
>  }
> ```